### PR TITLE
Bugfixes for requests (#5)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Andreas Hasenkopf'
 author = 'Andreas Hasenkopf'
 
 # The short X.Y version
-version = '0.1.6'
+version = '0.1.7'
 # The full version, including alpha/beta/rc tags
-release = '0.1.6'
+release = '0.1.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+0.1.7
+-----
+
+* Define ``Content-Type`` header in requests in
+  :py:meth:`osctiny.osc.Osc.request`
+* Use new parameter ``params`` in calls of :py:meth:`osctiny.osc.Osc.request`
+* Added parameter ``deleted`` to :py:math:`osctiny.packages.get_list`
+
 0.1.6
 -----
 

--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -3,4 +3,4 @@ from .osc import Osc
 
 
 __all__ = ['Osc']
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/osctiny/bs_requests.py
+++ b/osctiny/bs_requests.py
@@ -33,7 +33,7 @@ class Request(ExtensionBase):
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path),
             method="GET",
-            data=params
+            params=params
         )
 
         return self.osc.get_objectified_xml(response)
@@ -52,12 +52,10 @@ class Request(ExtensionBase):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         request_id = self._validate_id(request_id)
-        withhistory = '1' if withhistory else '0'
-        withfullhistory = '1' if withfullhistory else '0'
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path + request_id),
             method="GET",
-            data={
+            params={
                 'withhistory': withhistory,
                 'withfullhistory': withfullhistory
             }
@@ -112,7 +110,7 @@ class Request(ExtensionBase):
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path + request_id),
             method="POST",
-            data=kwargs
+            params=kwargs
         )
 
         if kwargs.get("view", "plain") == "xml":
@@ -133,13 +131,15 @@ class Request(ExtensionBase):
         """
         request_id = self._validate_id(request_id)
         url = urljoin(self.osc.url, '/comments' + self.base_path + request_id)
+        params = {}
         if parent_id and str(parent_id).isnumeric():
-            url += "?parent_id={}".format(parent_id)
+            params["parent_id"] = parent_id
 
         response = self.osc.request(
             url=url,
             method="POST",
-            data=comment
+            data=comment,
+            params=params
         )
         parsed = self.osc.get_objectified_xml(response)
         if response.status_code == 200 and parsed.get("code") == "ok":

--- a/osctiny/buildresults.py
+++ b/osctiny/buildresults.py
@@ -39,7 +39,7 @@ class Build(ExtensionBase):
             method="GET",
             url=urljoin(self.osc.url, "{}/{}/_result".format(self.base_path,
                                                              project)),
-            data=params
+            params=params
         )
 
         return self.osc.get_objectified_xml(response)
@@ -63,7 +63,7 @@ class Build(ExtensionBase):
             url=urljoin(self.osc.url, "{}/{}/{}/{}/{}".format(
                 self.base_path, project, repo, arch, package
             )),
-            data=params
+            params=params
         )
 
         return self.osc.get_objectified_xml(response)

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -7,7 +7,6 @@ import gc
 import re
 from ssl import get_default_verify_paths
 import time
-from urllib.parse import urlencode
 import warnings
 
 # pylint: disable=no-name-in-module
@@ -121,7 +120,7 @@ class Osc:
         # Just in case ;-)
         gc.collect()
 
-    def request(self, url, data=None, method="GET", stream=False,
+    def request(self, url, method="GET", stream=False, data=None, params=None,
                 raise_for_status=True, timeout=None):
         """
         Perform HTTP(S) request
@@ -146,6 +145,10 @@ class Osc:
 
         .. versionchanged:: 0.1.5
             Retry sending the request, if the remote host disconnects
+
+        .. versionadded:: 0.1.7
+
+            * Added parameter `params`
 
         :param url: Full URL
         :param data: Data to be included as GET or POST parameters in request
@@ -172,18 +175,15 @@ class Osc:
         else:
             session = self.session
 
-        if isinstance(data, dict):
-            comment = data.pop("comment", {})
-            url += "?" + urlencode(self.handle_params(data))
-            data = comment
-
         req = Request(
             method,
             url,
             auth=self.auth,
-            data=self.handle_params(data)
+            data=self.handle_params(data),
+            params=self.handle_params(params)
         )
         prepped_req = session.prepare_request(req)
+        prepped_req.headers['Content-Type'] = "application/octet-stream"
         settings = session.merge_environment_settings(
             prepped_req.url, {}, None, None, None
         )

--- a/osctiny/packages.py
+++ b/osctiny/packages.py
@@ -20,17 +20,23 @@ class Package(ExtensionBase):
     base_path = "/source"
     new_package_meta_templ = "<package><title/><description/></package>"
 
-    def get_list(self, project):
+    def get_list(self, project, deleted=False):
         """
         Get packages from project
 
+        .. versionadded:: 0.1.7
+            Parameter ``deleted``
+
         :param project: name of project
+        :param deleted: Show deleted packages instead
         :return: Objectified XML element
         :rtype: lxml.objectify.ObjectifiedElement
         """
+        params = {"deleted": deleted}
         response = self.osc.request(
             url=urljoin(self.osc.url, "{}/{}".format(self.base_path, project)),
-            method="GET"
+            method="GET",
+            params=params
         )
 
         return self.osc.get_objectified_xml(response)
@@ -61,7 +67,7 @@ class Package(ExtensionBase):
                 "{}/{}/{}/_meta".format(self.base_path, project, package)
             ),
             method="GET",
-            data=params
+            params=params
         )
 
         if blame:
@@ -133,7 +139,7 @@ class Package(ExtensionBase):
                 "{}/{}/{}".format(self.base_path, project, package)
             ),
             method="GET",
-            data=params
+            params=params
         )
 
         return self.osc.get_objectified_xml(response)
@@ -164,7 +170,7 @@ class Package(ExtensionBase):
             ),
             method="GET",
             stream=True,
-            data={'meta': meta, 'rev': rev}
+            params={'meta': meta, 'rev': rev}
         )
 
         return response
@@ -320,7 +326,7 @@ class Package(ExtensionBase):
                 "{}/{}/{}".format(self.base_path, project, package)
             ),
             method="POST",
-            data=params
+            params=params
         )
 
         if cmd != "diff" or params.get("view", None) == "xml":
@@ -382,7 +388,7 @@ class Package(ExtensionBase):
         :return: ``True``, if successful. Otherwise API response
         :rtype: bool or lxml.objectify.ObjectifiedElement
         """
-        params = {'force': force, 'comment': comment}
+        params = {'force': force}
 
         response = self.osc.request(
             url=urljoin(
@@ -390,7 +396,8 @@ class Package(ExtensionBase):
                 "/".join((self.base_path, project, package))
             ),
             method="DELETE",
-            data=params
+            params=params,
+            data=comment
         )
 
         parsed = self.osc.get_objectified_xml(response)

--- a/osctiny/projects.py
+++ b/osctiny/projects.py
@@ -39,7 +39,7 @@ class Project(ExtensionBase):
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path),
             method="GET",
-            data={'deleted': deleted}
+            params={'deleted': deleted}
         )
 
         return self.osc.get_objectified_xml(response)
@@ -141,7 +141,7 @@ class Project(ExtensionBase):
                 "{}/{}/{}".format(self.base_path, project, directory)
             ),
             method="GET",
-            data=kwargs
+            params=kwargs
         )
 
         return self.osc.get_objectified_xml(response)
@@ -269,13 +269,15 @@ class Project(ExtensionBase):
         :rtype: bool or lxml.objectify.ObjectifiedElement
         """
         url = urljoin(self.osc.url, '/comments/project/' + project)
+        params = {}
         if parent_id and str(parent_id).isnumeric():
-            url += "?parent_id={}".format(parent_id)
+            params["parent_id"] = parent_id
 
         response = self.osc.request(
             url=url,
             method="POST",
-            data=comment
+            data=comment,
+            params=params
         )
         parsed = self.osc.get_objectified_xml(response)
         if response.status_code == 200 and parsed.get("code") == "ok":
@@ -306,7 +308,7 @@ class Project(ExtensionBase):
                 self.base_path, project
             )),
             method="GET",
-            data=kwargs
+            params=kwargs
         )
 
         return self.osc.get_objectified_xml(response)
@@ -324,7 +326,7 @@ class Project(ExtensionBase):
         :return: ``True``, if successful. Otherwise API response
         :rtype: bool or lxml.objectify.ObjectifiedElement
         """
-        params = {'force': force, 'comment': comment}
+        params = {'force': force}
 
         response = self.osc.request(
             url=urljoin(
@@ -332,7 +334,8 @@ class Project(ExtensionBase):
                 "/".join((self.base_path, project))
             ),
             method="DELETE",
-            data=params
+            params=params,
+            data=comment
         )
 
         parsed = self.osc.get_objectified_xml(response)

--- a/osctiny/search.py
+++ b/osctiny/search.py
@@ -36,7 +36,7 @@ class Search(ExtensionBase):
         kwargs["match"] = xpath
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path + path.lstrip("/")),
-            data=kwargs,
+            params=kwargs,
             method='GET'
         )
         return self.osc.get_objectified_xml(response)

--- a/osctiny/users.py
+++ b/osctiny/users.py
@@ -26,7 +26,7 @@ class Group(ExtensionBase):
         response = self.osc.request(
             url=urljoin(self.osc.url, self.base_path),
             method="GET",
-            data=data
+            params=data
         )
 
         return self.osc.get_objectified_xml(response)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.1.6',
+    version='0.1.7',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Use `params` instead of `data` when calling `Osc.request`
* Use content type in requests
* Version bump to 0.1.7