### PR TITLE
Add Python2.7 support

### DIFF
--- a/osctiny/extensions/bs_requests.py
+++ b/osctiny/extensions/bs_requests.py
@@ -2,7 +2,8 @@
 Requests extension
 ------------------
 """
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
+from builtins import str as text_type
 
 from ..utils.base import ExtensionBase
 
@@ -15,7 +16,7 @@ class Request(ExtensionBase):
 
     @staticmethod
     def _validate_id(request_id):
-        request_id = str(request_id)
+        request_id = text_type(request_id)
         if not request_id.isnumeric():
             raise ValueError(
                 "Request ID must be numeric! Got instead: {}".format(request_id)

--- a/osctiny/extensions/buildresults.py
+++ b/osctiny/extensions/buildresults.py
@@ -3,7 +3,7 @@ Build result extension
 ----------------------
 """
 # pylint: disable=too-few-public-methods
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/extensions/comments.py
+++ b/osctiny/extensions/comments.py
@@ -3,7 +3,7 @@ Comments extension
 ------------------
 """
 import os
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -4,7 +4,7 @@ Packages extension
 """
 import errno
 import os
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from lxml.etree import tounicode, SubElement, Element
 from lxml.objectify import fromstring

--- a/osctiny/extensions/projects.py
+++ b/osctiny/extensions/projects.py
@@ -3,7 +3,7 @@ Projects extension
 ------------------
 """
 import re
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from lxml.etree import tounicode
 from lxml.objectify import fromstring

--- a/osctiny/extensions/search.py
+++ b/osctiny/extensions/search.py
@@ -2,7 +2,7 @@
 Search extension
 ----------------
 """
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/extensions/users.py
+++ b/osctiny/extensions/users.py
@@ -2,7 +2,7 @@
 Persons and groups extension
 ----------------------------
 """
-from urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -2,6 +2,7 @@
 Main API access
 ---------------
 """
+from builtins import str as text_type
 from io import BufferedReader, BytesIO, StringIO
 import gc
 import re
@@ -191,6 +192,7 @@ class Osc:
         )
         prepped_req = session.prepare_request(req)
         prepped_req.headers['Content-Type'] = "application/octet-stream"
+        prepped_req.headers['Accept'] = "application/xml"
         settings = session.merge_environment_settings(
             prepped_req.url, {}, None, None, None
         )
@@ -227,12 +229,12 @@ class Osc:
         if isinstance(params, bytes):
             return params
 
-        if isinstance(params, str):
-            return params.encode()
+        if isinstance(params, text_type):
+            return params.encode('utf-8')
 
         if isinstance(params, StringIO):
             params.seek(0)
-            return params.read().encode()
+            return params.read().encode('utf-8')
 
         if isinstance(params, (BufferedReader, BytesIO)):
             params.seek(0)
@@ -265,7 +267,8 @@ class Osc:
         except ValueError:
             # Just in case OBS returns a Unicode string with encoding
             # declaration
-            if isinstance(response.text, str) and "encoding=" in response.text:
+            if isinstance(response.text, text_type) and \
+                    "encoding=" in response.text:
                 return fromstring(
                     re.sub(r'encoding="[^"]+"', "", response.text)
                 )

--- a/osctiny/tests/base.py
+++ b/osctiny/tests/base.py
@@ -1,5 +1,9 @@
+# -*- coding: utf-8 -*-
+from future.standard_library import install_aliases
+install_aliases()
+
 from io import IOBase
-from unittest import TestCase
+from unittest2 import TestCase
 from urllib.parse import parse_qs
 
 import responses
@@ -34,7 +38,7 @@ class CallbackFactory:
             body.seek(0)
             body = body.read()
         if hasattr(body, "decode"):
-            body = body.decode()
+            body = body.decode('utf-8')
         params = parse_qs(body)
         headers = {
             "Cache-Control": "max-age=0, private, must-revalidate",
@@ -53,7 +57,7 @@ class CallbackFactory:
 class OscTest(TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
+        super(OscTest, cls).setUpClass()
         cls.osc = Osc(
             url="http://api.example.com",
             username="foobar",

--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ..extensions import projects
 from .base import OscTest
 
@@ -12,7 +13,7 @@ class BasicTest(OscTest):
             (None, {}),
             (1, {}),
             ("hello world", b"hello world"),
-            ("føø bær", b"f\xc3\xb8\xc3\xb8 b\xc3\xa6r"),
+            (u"føø bær", b"f\xc3\xb8\xc3\xb8 b\xc3\xa6r"),
             (
                 {"view": "xml", "withissues": 1},
                 {b"view": b"xml", b"withissues": b"1"}

--- a/osctiny/tests/test_build.py
+++ b/osctiny/tests/test_build.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import urlparse, parse_qs
+from six.moves.urllib_parse import urlparse, parse_qs
 
 from requests.exceptions import HTTPError
 import responses

--- a/osctiny/tests/test_datadir.py
+++ b/osctiny/tests/test_datadir.py
@@ -1,4 +1,7 @@
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 # Absolute import needed for mocking ;)
 from ..utils.base import DataDir

--- a/osctiny/tests/test_packages.py
+++ b/osctiny/tests/test_packages.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
 from io import StringIO, BytesIO, IOBase
 import re
 from unittest import skip
+from builtins import str as text_type
 
 import responses
 
@@ -156,7 +158,7 @@ class TestPackage(OscTest):
             response = self.osc.packages.get_meta(
                 "SUSE:SLE-12-SP1:Update", "python.8549", blame=True
             )
-            self.assertTrue(isinstance(response, str))
+            self.assertTrue(isinstance(response, text_type))
 
     @skip("No test data available")
     @responses.activate
@@ -245,7 +247,7 @@ class TestPackage(OscTest):
         response = self.osc.packages.cmd(
             "SUSE:SLE-12-SP1:Update", "python.8549", "diff"
         )
-        self.assertTrue(isinstance(response, str))
+        self.assertTrue(isinstance(response, text_type))
         self.assertIn(
             "++#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE", response
         )
@@ -336,7 +338,7 @@ class TestPackage(OscTest):
 
     @responses.activate
     def test_push_file(self):
-        content = """
+        content = u"""
         ლ(ಠ益ಠ)ლ            ლ(ಠ益ಠ)ლ
         Lorem ipsum dolor sit amet,
         consectetur adipiscing elit.
@@ -368,22 +370,22 @@ class TestPackage(OscTest):
 
         with self.subTest("as unicode"):
             self.osc.packages.push_file("prj", "pkg", "readme.txt", content)
-            self.assertEqual(bodies[-1], content.encode())
+            self.assertEqual(bodies[-1], content.encode('utf-8'))
 
         with self.subTest("as bytes"):
             self.osc.packages.push_file("prj", "pkg", "readme.txt",
-                                        content.encode())
-            self.assertEqual(bodies[-1], content.encode())
+                                        content.encode('utf-8'))
+            self.assertEqual(bodies[-1], content.encode('utf-8'))
 
         with self.subTest("as StringIO"):
             self.osc.packages.push_file("prj", "pkg", "readme.txt",
                                         StringIO(content))
-            self.assertEqual(bodies[-1], content.encode())
+            self.assertEqual(bodies[-1], content.encode('utf-8'))
 
         with self.subTest("as BytesIO"):
             self.osc.packages.push_file("prj", "pkg", "readme.txt",
-                                        BytesIO(content.encode()))
-            self.assertEqual(bodies[-1], content.encode())
+                                        BytesIO(content.encode('utf-8')))
+            self.assertEqual(bodies[-1], content.encode('utf-8'))
 
     @responses.activate
     def test_aggregate(self):

--- a/osctiny/tests/test_projects.py
+++ b/osctiny/tests/test_projects.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import urlparse, parse_qs
+from six.moves.urllib_parse import urlparse, parse_qs
 
 from lxml.objectify import fromstring
 from requests.exceptions import HTTPError

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -1,5 +1,8 @@
+# -*- coding: utf-8 -*-
+from builtins import str as text_type
+
 import re
-from urllib.parse import urlparse, parse_qs
+from six.moves.urllib_parse import urlparse, parse_qs
 
 from lxml.objectify import ObjectifiedElement
 import responses
@@ -318,7 +321,7 @@ spec files:
 
 class TestRequest(OscTest):
     def setUp(self):
-        super().setUp()
+        super(TestRequest, self).setUp()
 
         self.mock_request(
             method=responses.GET,
@@ -374,7 +377,7 @@ class TestRequest(OscTest):
     def test_cmd(self):
         with self.subTest("plain diff"):
             response = self.osc.requests.cmd(30902, "diff")
-            self.assertTrue(isinstance(response, str))
+            self.assertTrue(isinstance(response, text_type))
             self.assertIn("changes files:", response)
             self.assertIn("+++ perl-XML-DOM-XPath.changes", response)
         with self.subTest("xml diff"):

--- a/osctiny/tests/test_search.py
+++ b/osctiny/tests/test_search.py
@@ -1,6 +1,5 @@
 import re
-from urllib.parse import urlparse, parse_qs
-
+from six.moves.urllib_parse import urlparse, parse_qs
 import responses
 
 from .base import OscTest, CallbackFactory

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
@@ -10,7 +10,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.1.12',
+    version='0.1.13',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -33,7 +33,7 @@ setup(
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Add Python2.7 support
Run unit test with `python2 -m unittest2` on python 2.7 (test cases on test_utils.py do not run).