### PR TITLE
Always enable build for aggregates

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+0.2.5
+-----
+
+* Changed :py:meth:`osctiny.extensions.packages.Package.aggregate` to always enable the build flag
+
 0.2.4
 -----
 

--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -479,7 +479,9 @@ class Package(ExtensionBase):
             meta_xml.set("name", tgt_package)
             meta_xml.set("project", tgt_project)
 
-            build_elem = meta_xml.find("build") or SubElement(meta_xml, "build")
+            build_elem = meta_xml.find("build")
+            if build_elem is None:
+                build_elem = SubElement(meta_xml, "build")
             build_elem.clear()
             SubElement(build_elem, "enable")
 

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -448,6 +448,10 @@ class Package(ExtensionBase):
 
         .. versionadded:: 0.1.2
 
+        .. versionchanged:: 0.2.5
+
+            When creating a new aggregate package, the build flag is always enabled.
+
         :param src_project: Name of source project
         :param src_package: Name of source package
         :param tgt_project: Name of target project
@@ -474,6 +478,10 @@ class Package(ExtensionBase):
             )
             meta_xml.set("name", tgt_package)
             meta_xml.set("project", tgt_project)
+
+            build_elem = meta_xml.find("build") or SubElement(meta_xml, "build")
+            build_elem.clear()
+            SubElement(build_elem, "enable")
 
             if not publish:
                 pub_elem = meta_xml.find("publish")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.2.4',
+    version='0.2.5',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
In order for the build service to actually collect the binaries, the build flag needs to be enabled on aggregated packages :bulb: 