### PR TITLE
New "Origin Manager" and dropped support for old Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8"
+  - "3.9"
 jobs:
   include:
     - name: "Pylint"
-      python: "3.6"
+      python: "3.8"
       script: pylint --rcfile=pylint.rc osctiny
-    - name: "Python: 3.4 (with old dep. versions)"
-      python: "3.4"
-      install: pip install -r requirements34.txt
-    - name: "Python: 2.7"
-      python: "2.7"
-      install: pip install -r requirements27.txt
-      script: python -m unittest2 discover
-install: pip install -r requirements.txt pylint
+    - name: "Python: 3.8"
+      python: "3.8"
+      script: coverage run --source=. --omit "*tests*" -m unittest discover
+      after_success:
+        coveralls
+install: pip install -r requirements.txt pylint coverage coveralls
 script: python -m unittest
 deploy:
   provider: pypi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ OSC Tiny
 ========
 
 [![Build Status](https://travis-ci.com/crazyscientist/osc-tiny.svg?branch=master)](https://travis-ci.com/crazyscientist/osc-tiny)
+[![Coverage Status](https://coveralls.io/repos/github/crazyscientist/osc-tiny/badge.svg)](https://coveralls.io/github/crazyscientist/osc-tiny)
+[![PyPI version](https://badge.fury.io/py/osc-tiny.svg)](https://badge.fury.io/py/osc-tiny)
 
 This project aims to provide a minimalistic and transparent client for accessing
 the [OpenBuildService](https://openbuildservice.org/) 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -25,6 +25,9 @@ Extensions
 .. automodule:: osctiny.extensions.issues
     :members:
 
+.. automodule:: osctiny.extensions.origin
+    :members:
+
 .. automodule:: osctiny.extensions.packages
     :members:
 
@@ -47,4 +50,7 @@ Utilities
     :members:
 
 .. automodule:: osctiny.utils.changelog
+    :members:
+
+.. automodule:: osctiny.utils.mapping
     :members:

--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+0.3.0
+-----
+
+* Added :py:mod:`osctiny.extensions.origin`
+* Added :py:mod:`osctiny.utils.mapping`
+* Removed support for all Python version prior to 3.6
+
 0.2.5
 -----
 

--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.2.5"
+__version__ = "0.3.0"

--- a/osctiny/extensions/issues.py
+++ b/osctiny/extensions/issues.py
@@ -8,19 +8,8 @@ import os
 from six.moves.urllib.parse import urljoin
 from six import text_type
 
+from ..utils.backports import lru_cache
 from ..utils.base import ExtensionBase
-
-try:
-    from functools import lru_cache
-except ImportError:
-    # Whoever had the grandiose idea to backport this to Python2?
-    # pylint: disable=unused-argument
-    def lru_cache(*args, **kwargs):
-        """Dummy wrapper"""
-        def wrapper(fun):
-            return fun
-
-        return wrapper
 
 
 class Issue(ExtensionBase):

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -1,0 +1,532 @@
+"""
+Origin extension
+----------------
+
+This is an incomplete reference implementation of the `Origin Manager`_.
+
+The intention of this implementation is to quickly yield batch results. In doing so a different
+logic than in the original OSC plugin is used:
+
+* If a project inherits a package from another project, the origin is checked for the package in the
+  original project.
+* If the package has received submissions from potential origin projects, only those projects are
+  considered.
+* The first project from the origin configuration (including above limitations) containing the
+  package is considered as origin project.
+* If a project was found and if that project inherits the package, the original project is returned.
+
+.. _Origin Manager:
+    https://github.com/openSUSE/openSUSE-release-tools/blob/master/docs/origin-manager.md
+
+.. versionadded:: 0.3.0
+"""
+# pylint: disable=too-many-ancestors
+from collections import defaultdict
+import re
+from warnings import warn
+
+from lxml.objectify import ObjectifiedElement
+from yaml import load, CSafeLoader as SafeLoader
+
+from ..utils.backports import lru_cache
+from ..utils.base import ExtensionBase
+from ..utils.mapping import LazyOscMapable
+
+try:
+    from functools import cached_property
+except ImportError:
+    # Support for Python3 prior 3.8
+    from backports.cached_property import cached_property
+
+
+class DevelProjects(LazyOscMapable):
+    """
+    Lazy lookup table for package specific development projects
+    """
+
+    def get_devel_projects(self, *projects):
+        """
+        Find package specific development projects for (maintained) projects
+
+        :param str projects: One or more project names
+        :return: Dictionary with development projects per package
+        :rtype: dict
+        """
+        xpath = "state/@name='accepted' and action/@type='change_devel' and ({projects})"
+        xpath_projects = ["action/target/@project='{}'".format(project) for project in projects]
+        change_devels = self.osc.search.request(
+            xpath=xpath.format(projects=" or ".join(xpath_projects))
+        )
+
+        data = {}
+        for request in sorted(getattr(change_devels, "request", []),
+                              key=lambda x: x.state.get("when"), reverse=True):
+            key = (request.action.target.get("project"), request.action.target.get("package"))
+            if key not in data:
+                data[key] = request.action.source.get("project")
+                break
+
+        return data
+
+    def __missing__(self, key):
+        """
+        JIT processing of missing dictionary items
+
+        This method respects the default behavior of dictionary classes.
+        """
+        self._data[key] = self.get_devel_projects(key)
+
+
+class PackageMatrix(LazyOscMapable):
+    """
+    Lazy lookup matrix for package origins
+
+    This matrix collects for every project (provided as key) a dictionary with all allowed origin
+    projects and packages therein. If the origin project inherits the package from another project,
+    this information is available, too.
+
+    The matrix is not populated at initialization time. When the matrix for a project is requested
+    for the first, only the corresponding items are populated. Subsequent access to the same project
+    does not trigger new population. Hence "lazy".
+
+    Example:
+
+    .. code-block:: python
+
+        {
+            'openSUSE:Leap:15.2:Update': {
+                'SUSE:SLE-15-SP2:Update': {
+                    # ...
+                    'zeromq': ['SUSE:SLE-15:Update'],
+                    'zypper': ['SUSE:SLE-15-SP2:Update', 'SUSE:SLE-15-SP2:GA']
+                },
+                'SUSE:SLE-15-SP1:Update': {
+                    'zinnia-tomoe': ['SUSE:SLE-15:GA']
+                    # ...
+                },
+                'openSUSE:Factory': {
+                    # ...
+                    'zziplib': ['openSUSE:Factory']
+                }
+            },
+            'openSUSE:Leap:15.2': ...
+        }
+
+    :param osc_obj: An Osc instance to run queries
+    :type osc_obj: :py:class:`osctiny.osc.Osc`
+    :param expanded_origins: Lookup dictionary with all possible origin projects
+    :type expanded_origins: :py:meth:`Origin.expanded_origins`
+    """
+    def __init__(self, osc_obj, expanded_origins, **kwargs):
+        super().__init__(osc_obj=osc_obj, **kwargs)
+        self._expanded_origins = expanded_origins
+
+    def __missing__(self, key):
+        """
+        JIT processing of missing matrix items
+
+        This method respects the default behavior of dictionary classes.
+        """
+        def _inherit(proj, o_proj):
+            if proj == o_proj:
+                return [proj]
+            return [proj, o_proj]
+
+        if key in self._expanded_origins:
+            self._data[key] = {
+                origin_project: {
+                    entry.get("name"): _inherit(origin_project, entry.get("originproject"))
+                    for entry in getattr(self.osc.projects.get_files(project=origin_project,
+                                                                     expand='1'), "entry", [])
+                }
+                for origin_project in self._expanded_origins[key]
+                if origin_project not in ["<devel>", "*", "*~"]
+            }
+            return
+        raise KeyError("'{}' is not an origin project".format(key))
+
+
+class Origin(ExtensionBase):
+    """
+    Query tool to find the origin of packages in maintained projects
+
+    .. versionadded:: 0.3.0
+    """
+    _origin_priority_pattern = re.compile(
+        r"^(?P<family>SUSE:[^:-]+|openSUSE:[^:]+)[:-]"
+        r"(?P<major>\d+)((\.|-SP)(?P<minor>\d+))?"
+        r"(:(?P<tail>.+))?$"
+    )
+
+    def __init__(self, osc_obj):
+        super().__init__(osc_obj)
+        self._devel_projects = None
+        self._package_matrix = None
+
+    def family_sort_key(self, key):
+        """
+        Provides a numeric key for sorting projects of the same family
+
+        :param str key: Project name
+        :return: Numeric value representing the version and priority of projects
+        :rtype: float
+        """
+        if isinstance(key, int):
+            return key
+        if not isinstance(key, str):
+            return -1
+
+        match = self._origin_priority_pattern.match(key)
+        if not match:
+            return 0
+
+        tail_mod = 0.
+        if match.group("tail"):
+            parts = match.group("tail").split(":")
+            if "Update" in parts:
+                tail_mod += .0005
+            if "workarounds" in parts:
+                tail_mod += .0006
+            if len(parts) > 1:
+                tail_mod += .0001
+
+        value = float(match.group("major") or 0) + .01*float(match.group("minor") or 0) + tail_mod
+        return value
+
+    def family_sorter(self, unsorted_list):
+        """
+        Sort consecutive projects of the same family
+
+        In case the configuration does not list the projects in a meaningful way, they are
+        sorted now to avoid the need to check the package histories for every package.
+
+        .. note::
+
+            This sorter is only allowed to change the order of consecutive projects belonging to the
+            same family.
+
+            Consider this a workaround for
+            `this issue <https://github.com/openSUSE/openSUSE-release-tools/issues/2506>`_.
+
+        :param unsorted_list: List with project names
+        :type unsorted_list: list of str
+        :return: Generator with sorted list items
+        :rtype: generator
+        """
+        i = 0
+        while i < len(unsorted_list):
+            match = self._origin_priority_pattern.match(unsorted_list[i])
+            if not match:
+                yield unsorted_list[i]
+                i += 1
+                continue
+
+            end_index = -1
+            for j in range(i+1, len(unsorted_list)):
+                match2 = self._origin_priority_pattern.match(unsorted_list[j])
+                if not match2:
+                    break
+                if match2.group("family") != match.group("family"):
+                    break
+                end_index = j
+            if end_index > i:
+                yield from sorted(unsorted_list[i:end_index+1], key=self.family_sort_key,
+                                  reverse=True)
+                i = end_index+1
+            else:
+                yield unsorted_list[i]
+                i += 1
+
+    @property
+    def devel_projects(self):
+        """
+        Delayed initialization of the package specific development project dictionary
+
+        This dictionary is populated in a lazy/JIT fashion.
+
+        :return: :py:class:`DevelProjects`
+        """
+        if self._devel_projects is None:
+            self._devel_projects = DevelProjects(osc_obj=self.osc)
+        return self._devel_projects
+
+    @property
+    def package_matrix(self):
+        """
+        Delayed initialization of the lookup package matrix.
+
+        The matrix is populated in a lazy/JIT fashion.
+
+        :return: :py:class:`PackageMatrix`
+        """
+        if self._package_matrix is None:
+            self._package_matrix = PackageMatrix(osc_obj=self.osc,
+                                                 expanded_origins=self.expanded_origins)
+        return self._package_matrix
+
+    @cached_property
+    def maintenance_project(self):
+        """
+        Get the maintenance project
+
+        This project is important, because it's meta can provide the list of maintained projects.
+
+        :return: Objectified XML element or ``None``
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        response = self.osc.search.project(xpath="attribute/@name='OBS:MaintenanceProject'")
+        projects = getattr(response, "project", [])
+        if len(projects) < 1:
+            warn("The build service defines no maintenance projects!")
+            return None
+        if len(projects) > 1:
+            warn("The build service defines multiple maintenance projects!")
+
+        return projects[0]
+
+    @cached_property
+    def maintained_projects(self, from_project=None):
+        """
+        Get the list of maintained projects
+
+        By default this property uses :py:meth:`maintenance_project` and allows usage of a specified
+        ``from_project`` instead.
+
+        :param from_project: The maintenance project to query
+        :return: Objectified XML element
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        from_project = from_project or self.maintenance_project
+        if not isinstance(from_project, ObjectifiedElement):
+            from_project = self.osc.projects.get_meta(project=from_project)
+
+        return [m.get("project") for m in from_project.xpath("maintenance/maintains")]
+
+    @lru_cache(maxsize=16)
+    def get_project_origin_config(self, project):
+        """
+        Get the Origin configuration for ``project``
+
+        This method returns the decoded YAML data, e.g. for "openSUSE:Leap:15.2:Update":
+
+        .. code-block:: json
+
+            {
+              "origins": [
+                {
+                  "<devel>": {}
+                },
+                {
+                  "SUSE:SLE-15:Update": {
+                    "maintainer_review_initial": false
+                  }
+                },
+                {
+                  "SUSE:SLE-15-SP1:Update": {
+                    "maintainer_review_initial": false
+                  }
+                },
+                {
+                  "SUSE:SLE-15-SP2:Update": {
+                    "maintainer_review_initial": false
+                  }
+                },
+                {
+                  "openSUSE:Leap:15.1:Update": {
+                    "pending_submission_allow": true
+                  }
+                },
+                {
+                  "openSUSE:Factory": {
+                    "pending_submission_allow": true
+                  }
+                },
+                {
+                  "*~": {}
+                }
+              ],
+              "fallback-group": "origin-reviewers-maintenance"
+            }
+
+        :param name project: The project name
+        :return: Configuration content
+        :rtype: dict
+        """
+        encoded_attrib = self.osc.projects.get_attribute(project=project,
+                                                         attribute="OSRT:OriginConfig")
+
+        return load(encoded_attrib.attribute.value.text, Loader=SafeLoader)
+
+    @cached_property
+    def expanded_origins(self):
+        """
+        Expand the projects from the Origin Configuration
+
+        This property returns all the expanded origin projects for all projects that have the
+        ``OSRT:OriginConfig`` attribute set in build service.
+
+        .. note::
+
+            Even if ``OSRT:OriginConfig`` explicitly defines a bogus order of projects, e.g.
+
+            * ``SUSE:SLE-15:Update``
+            * ``SUSE:SLE-15-SP1:Update``
+            * ``SUSE:SLE-15-SP2:Update``
+
+            this method will rearrange the projects in a meaningful way, e.g. into:
+
+            * ``SUSE:SLE-15-SP2:Update``
+            * ``SUSE:SLE-15-SP1:Update``
+            * ``SUSE:SLE-15:Update``
+
+            Consider this a workaround for
+            `this issue <https://github.com/openSUSE/openSUSE-release-tools/issues/2506>`_.
+
+        :return: Dictionary with lists of origin project names for all projects
+        :rtype: dict
+        """
+        expanded = defaultdict(list)
+        projects = [project.get("name")
+                    for project in getattr(self.osc.search.search(
+                        path="project/id", xpath="attribute/@name='OSRT:OriginConfig'"
+                    ), "project", [])]
+
+        for configured_project in projects:
+            max_version = self.family_sort_key(configured_project)
+            for origin in self.get_project_origin_config(configured_project).get("origins"):
+                for _origin in origin:
+                    _origin = _origin.rstrip("~")
+                    if "*" not in _origin:
+                        # no family expansion
+                        expanded[configured_project].append(_origin)
+                        continue
+
+                    # family expansion
+                    parts = _origin.rsplit("*", 1)
+                    if parts[0] in ['', "*"]:
+                        continue
+
+                    xpath = "starts-with(@name, '{}')".format(parts[0])
+                    if parts[1] != "":
+                        xpath += " and contains(@name, ':{}')".format(parts[1])
+
+                    family = [proj.get("name")
+                              for proj in getattr(self.osc.search.search("project/id", xpath=xpath),
+                                                  "project", [])]
+
+                    family.sort(key=self.family_sort_key, reverse=True)
+                    expanded[configured_project] += [f
+                                                     for f in family
+                                                     if self.family_sort_key(f) <= max_version]
+            # Note: The order of origins in the config might be not the intended one. Se we sort
+            # them the right way.
+            expanded[configured_project] = list(self.family_sorter(expanded[configured_project]))
+
+        return expanded
+
+    @lru_cache(maxsize=256)
+    def is_linked(self, package, project):
+        """
+        Guess whether a package is a link source (with incident number as suffix).
+
+        :param package: Package name to check
+        :param project: Project name containing the package
+        :return: ``True``, if package name seems to have an incident ID as suffix
+        """
+        without_suffix = re.sub(r"\.\d+$", "", package)
+        if without_suffix == package:
+            return False
+
+        package_list = {key for pkg in self.package_matrix[project].values() for key in pkg if pkg}
+        if without_suffix in package_list:
+            return True
+
+        return False
+
+    def get_origin_from_submissions(self, package, project):
+        """
+        Get potential origin projects from accepted submissions (aka. requests)
+
+        This method returns the source project names from accepted requests.
+
+        :param str package: Target package name
+        :param str project: Target project name
+        :return: Set of source project names
+        :rtype: set or str
+        """
+        xpath = "action/target/@project='{project}' and action/target/@package='{package}' " \
+                "and state/@name='accepted'"
+        response = self.osc.search.request(xpath=xpath.format(project=project, package=package))
+        sources = response.xpath("request/action/source")
+        return {s.get("project") for s in sources}
+
+    def find_package_origin(self, package, project, resolve_inheritance=True):
+        """
+        Find the origin project for ``package`` in ``project``
+
+        This method will return simply ``None`` for patchinfo packages and packages with an incident
+        ID as suffix.
+
+        .. important::
+
+            When you want to check multiple packages by multiple calls to this method, you should
+            resolve from where ``project`` inherits the package for all your (package, project)
+            pairs in advance and set ``resolve_inheritance`` to ``False`` to speed up the response
+            time.
+
+        :param str package: Package name
+        :param str project: Project name
+        :param bool resolve_inheritance: Trigger to cause this method to replace ``project`` with
+                                         the project from which ``package`` is inherited from
+        :return: Origin project name or ``None``
+        :rtype: str
+        """
+        if package.startswith("patchinfo") or self.is_linked(package, project):
+            # We do not care about patchinfo packages nor packages with incident ID suffixes
+            return None
+
+        if resolve_inheritance:
+            response = self.osc.packages.get_files(package=package, project=project, withlinked=1)
+            links = response.xpath("linkinfo/linked")
+            if len(links) > 0:
+                project = links[-1].get("project")
+
+        if "<devel>" in self.expanded_origins[project] \
+                and (project, package) in self.devel_projects[project]:
+            return self.devel_projects[project][(project, package)]
+
+        request_origins = self.get_origin_from_submissions(package=package, project=project) \
+                          & set(self.expanded_origins[project])
+        for candidate in self.expanded_origins[project]:
+            if candidate in ["<devel>", "*", "*~"]:
+                continue
+
+            matrix = self.package_matrix[project][candidate]
+            if package in matrix:
+                origin_projects = matrix[package]
+                # If the apparent origin project inherits the package, we consider the project from
+                # which the package is inherited to be the correct answer.
+                for proj in origin_projects[::-1]:
+                    if not request_origins or proj in request_origins:
+                        return origin_projects[-1]
+
+        return None
+
+    def list(self, project):
+        """
+        List all packages in a maintained project and their origin projects
+
+        :param str project: Project name
+        :return: Generator of pairs: ('pkg', 'origin')
+        :rtype: generator
+        """
+        packages = self.osc.projects.get_files(project, expand='1')
+
+        for package in getattr(packages, "entry", []):
+            name = package.get("name")
+            oproject = package.get("originproject")
+            if name.startswith("patchinfo") or self.is_linked(name, oproject):
+                # We do not care about patchinfo packages nor packages with incident ID suffixes
+                continue
+            yield name, self.find_package_origin(package=name, project=oproject,
+                                                 resolve_inheritance=False)

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -2,7 +2,7 @@
 Origin extension
 ----------------
 
-This is an incomplete reference implementation of the `Origin Manager`_.
+This is a runtime optimized implementation of the `Origin Manager`_.
 
 The intention of this implementation is to quickly yield batch results. In doing so a different
 logic than in the original OSC plugin is used:

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -30,7 +30,7 @@ from yaml import load, CSafeLoader as SafeLoader
 
 from ..utils.backports import lru_cache
 from ..utils.base import ExtensionBase
-from ..utils.mapping import LazyOscMapable
+from ..utils.mapping import LazyOscMappable
 
 try:
     from functools import cached_property
@@ -39,7 +39,7 @@ except ImportError:
     from backports.cached_property import cached_property
 
 
-class DevelProjects(LazyOscMapable):
+class DevelProjects(LazyOscMappable):
     """
     Lazy lookup table for package specific development projects
     """
@@ -77,7 +77,7 @@ class DevelProjects(LazyOscMapable):
         self._data[key] = self.get_devel_projects(key)
 
 
-class PackageMatrix(LazyOscMapable):
+class PackageMatrix(LazyOscMappable):
     """
     Lazy lookup matrix for package origins
 

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -15,12 +15,12 @@ from lxml.objectify import fromstring, makeparser
 from requests import Session, Request
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import ConnectionError as _ConnectionError
-from six import text_type
 
 from .extensions.buildresults import Build
 from .extensions.comments import Comment
 from .extensions.distributions import Distribution
 from .extensions.issues import Issue
+from .extensions.origin import Origin
 from .extensions.packages import Package
 from .extensions.projects import Project
 from .extensions.bs_requests import Request as BsRequest
@@ -70,6 +70,8 @@ class Osc:
           - :py:attr:`comments`
         * - :py:class:`osctiny.extensions.distributions.Distribution`
           - :py:attr:`distributions`
+        * - :py:class:`osctiny.extensions.origin.Origin`
+          - :py:attr:`origins`
 
     :param url: API URL of a BuildService instance
     :param username: Credential for login
@@ -88,6 +90,9 @@ class Osc:
 
     .. versionadded:: 0.2.3
         The ``distributions`` extension
+
+    .. versionadded:: 0.3.0
+        The ``origins`` extension
 
     .. _SSL Cert Verification:
         http://docs.python-requests.org/en/master/user/advanced/
@@ -119,6 +124,7 @@ class Osc:
         self.distributions = Distribution(osc_obj=self)
         self.groups = Group(osc_obj=self)
         self.issues = Issue(osc_obj=self)
+        self.origins = Origin(osc_obj=self)
         self.packages = Package(osc_obj=self)
         self.projects = Project(osc_obj=self)
         self.requests = BsRequest(osc_obj=self)
@@ -242,7 +248,7 @@ class Osc:
         if isinstance(params, bytes):
             return params
 
-        if isinstance(params, text_type):
+        if isinstance(params, str):
             return params.encode('utf-8')
 
         if isinstance(params, StringIO):
@@ -280,7 +286,7 @@ class Osc:
         :rtype response: :py:class:`requests.Response`
         :return: :py:class:`lxml.objectify.ObjectifiedElement`
         """
-        if isinstance(response, text_type):
+        if isinstance(response, str):
             text = response
         else:
             text = response.text
@@ -290,7 +296,7 @@ class Osc:
         except ValueError:
             # Just in case OBS returns a Unicode string with encoding
             # declaration
-            if isinstance(text, text_type) and \
+            if isinstance(text, str) and \
                     "encoding=" in text:
                 return fromstring(
                     re.sub(r'encoding="[^"]+"', "", text)

--- a/osctiny/tests/base.py
+++ b/osctiny/tests/base.py
@@ -1,14 +1,8 @@
-from __future__ import unicode_literals
-import sys
-if sys.version_info.major < 3:
-    from unittest2 import TestCase
-else:
-    from unittest import TestCase
-
 from io import IOBase
+from unittest import TestCase
+from urllib.parse import parse_qs, urlparse
 
 import responses
-from six.moves.urllib_parse import parse_qs, urlparse
 
 from osctiny import Osc
 

--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from ..extensions import projects
 from .base import OscTest
 

--- a/osctiny/tests/test_build.py
+++ b/osctiny/tests/test_build.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 import re
-from six.moves.urllib_parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 
 from requests.exceptions import HTTPError
 import responses

--- a/osctiny/tests/test_comments.py
+++ b/osctiny/tests/test_comments.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import re
 
 from lxml.objectify import ObjectifiedElement

--- a/osctiny/tests/test_datadir.py
+++ b/osctiny/tests/test_datadir.py
@@ -1,9 +1,4 @@
-from __future__ import unicode_literals
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 # Absolute import needed for mocking ;)
 from ..utils.base import DataDir

--- a/osctiny/tests/test_distributions.py
+++ b/osctiny/tests/test_distributions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf8 -*-
-from __future__ import unicode_literals
 import re
 
 from requests.exceptions import HTTPError

--- a/osctiny/tests/test_issues.py
+++ b/osctiny/tests/test_issues.py
@@ -1,7 +1,5 @@
 # -*- coding: utf8 -*-
-from __future__ import unicode_literals
 import re
-from sys import version_info
 
 from lxml.objectify import ObjectifiedElement
 from requests.exceptions import HTTPError
@@ -148,5 +146,4 @@ class TestIssue(OscTest):
             self.assertTrue(hasattr(response, "summary"))
             # to whom it may concern: `responses.calls` does not get reset
             # between sub-tests
-            self.assertEqual(len(responses.calls),
-                             6 if version_info.major < 3 else 4)
+            self.assertEqual(len(responses.calls), 4)

--- a/osctiny/tests/test_origin.py
+++ b/osctiny/tests/test_origin.py
@@ -1,0 +1,260 @@
+import re
+
+import responses
+
+from .base import OscTest, CallbackFactory
+
+
+class OriginTest(OscTest):
+    def test_origin_sort_key(self):
+        pattern = self.osc.origins._origin_priority_pattern
+
+        data = (
+            # project name, expected
+            ('SUSE:SLE-15:Update',
+             {"family": "SUSE:SLE", "major": "15", "minor": None, "tail": "Update"}),
+            ('SUSE:SLE-15-SP1:Update',
+             {"family": "SUSE:SLE", "major": "15", "minor": "1", "tail": "Update"}
+             ),
+            ('SUSE:SLE-15-SP2:Update',
+             {"family": "SUSE:SLE", "major": "15", "minor": "2", "tail": "Update"}
+             ),
+            ('openSUSE:Leap:15.1',
+             {"family": "openSUSE:Leap", "major": "15", "minor": "1", "tail": None}
+             ),
+            ('openSUSE:Leap:15.1:Update',
+             {"family": "openSUSE:Leap", "major": "15", "minor": "1", "tail": "Update"}
+             ),
+            ('openSUSE:Factory', None),
+            ('openSUSE:Leap:15.1:NonFree:Update',
+             {"family": "openSUSE:Leap", "major": "15", "minor": "1", "tail": "NonFree:Update"}),
+            ('openSUSE:Factory:NonFree', None)
+        )
+
+        for project, expected in data:
+            with self.subTest(project):
+                match = pattern.match(project)
+                if expected is None:
+                    self.assertIsNone(match)
+                else:
+                    self.assertEqual(match.groupdict(), expected)
+
+    def test_family_sorter(self):
+        data = (
+            # input, expected
+            (
+                ['<devel>', 'openSUSE:Leap:15.2:MicroOS:workarounds',
+                 'SUSE:SLE-15-SP2:Update:Products:MicroOS', 'SUSE:SLE-15-SP2:Update',
+                 'openSUSE:Leap:15.2:Update', 'openSUSE:Factory'],
+                ['<devel>', 'openSUSE:Leap:15.2:MicroOS:workarounds',
+                 'SUSE:SLE-15-SP2:Update:Products:MicroOS', 'SUSE:SLE-15-SP2:Update',
+                 'openSUSE:Leap:15.2:Update', 'openSUSE:Factory']
+            ),
+            (
+                ['<devel>', 'SUSE:SLE-15:Update', 'SUSE:SLE-15-SP1:Update',
+                 'SUSE:SLE-15-SP2:Update', 'openSUSE:Leap:15.1:Update', 'openSUSE:Factory'],
+                ['<devel>', 'SUSE:SLE-15-SP2:Update', 'SUSE:SLE-15-SP1:Update',
+                 'SUSE:SLE-15:Update', 'openSUSE:Leap:15.1:Update', 'openSUSE:Factory']
+            ),
+            (
+                ['<devel>', 'SUSE:SLE-15-SP2:GA', 'openSUSE:Leap:15.1:Update', 'openSUSE:Leap:15.1',
+                 'openSUSE:Factory'],
+                ['<devel>', 'SUSE:SLE-15-SP2:GA', 'openSUSE:Leap:15.1:Update', 'openSUSE:Leap:15.1',
+                 'openSUSE:Factory']
+            ),
+            (
+                ['<devel>', 'SUSE:SLE-15-SP2:GA', 'openSUSE:Leap:15.1', 'openSUSE:Leap:15.1:Update',
+                 'openSUSE:Factory'],
+                ['<devel>', 'SUSE:SLE-15-SP2:GA', 'openSUSE:Leap:15.1:Update', 'openSUSE:Leap:15.1',
+                 'openSUSE:Factory']
+            )
+        )
+
+        for unsorted, expected in data:
+            with self.subTest():
+                now_sorted = list(self.osc.origins.family_sorter(unsorted))
+                self.assertTrue(len(now_sorted) == len(unsorted) == len(expected))
+                self.assertEqual(expected, now_sorted)
+
+    @responses.activate
+    def test_maintained_projects(self):
+        def callback(headers, params, request):
+            status, body = 500, ""
+
+            if "OBS:MaintenanceProject" in "".join(params.get("match", [])):
+                status = 200
+                body = """
+                <collection matches="1">
+                    <project name="openSUSE:Maintenance" kind="maintenance">
+                      <title>The openSUSE Maintenance project</title>
+                      <description/>
+                      <group groupid="maintenance-opensuse.org" role="maintainer"/>
+                      <maintenance>
+                        <maintains project="openSUSE:Leap:15.1:Update"/>
+                        <maintains project="openSUSE:Leap:15.2:Update"/>
+                      </maintenance>
+                    </project>
+                    </collection>
+                """
+
+            return status, headers, body
+
+        self.mock_request(
+            method=responses.GET,
+            url=re.compile(self.osc.url + "/search/project/?"),
+            callback=CallbackFactory(callback)
+        )
+
+        with self.subTest("Maintenance Project"):
+            maint_project = self.osc.origins.maintenance_project
+            self.assertEqual(maint_project.get("name"), "openSUSE:Maintenance")
+            self.assertEqual(maint_project.get("kind"), "maintenance")
+
+        with self.subTest("Maintained Projects"):
+            self.assertEqual(self.osc.origins.maintained_projects,
+                             ["openSUSE:Leap:15.1:Update", "openSUSE:Leap:15.2:Update"])
+
+    @responses.activate
+    def test_get_project_origin_config(self):
+        self.mock_request(
+            method=responses.GET,
+            url=re.compile(self.osc.url + "/source/openSUSE:Leap:15.2:Update/_attribute"),
+            body="""
+<attributes>
+  <attribute name="OriginConfig" namespace="OSRT">
+    <value>origins:
+- &lt;devel&gt;: {}
+- SUSE:SLE-15:Update:
+    maintainer_review_initial: false
+- SUSE:SLE-15-SP1:Update:
+    maintainer_review_initial: false
+- SUSE:SLE-15-SP2:Update:
+    maintainer_review_initial: false
+- openSUSE:Leap:15.1:Update:
+    pending_submission_allow: true
+- openSUSE:Factory:
+    pending_submission_allow: true
+- '*~': {}
+fallback-group: 'origin-reviewers-maintenance'
+    </value>
+  </attribute>
+  <attribute name="Maintained" namespace="OBS"/>
+</attributes>"""
+        )
+
+        config = self.osc.origins.get_project_origin_config("openSUSE:Leap:15.2:Update")
+        self.assertEqual(config["origins"],
+                         [
+                             {'<devel>': {}},
+                             {'SUSE:SLE-15:Update': {'maintainer_review_initial': False}},
+                             {'SUSE:SLE-15-SP1:Update': {'maintainer_review_initial': False}},
+                             {'SUSE:SLE-15-SP2:Update': {'maintainer_review_initial': False}},
+                             {'openSUSE:Leap:15.1:Update': {'pending_submission_allow': True}},
+                             {'openSUSE:Factory': {'pending_submission_allow': True}},
+                             {'*~': {}}
+                         ])
+
+    @responses.activate
+    def test_expanded_origins(self):
+        def callback_attr(headers, params, request):
+            pattern = re.compile(r"openSUSE:Leap:15\.([12]):Update")
+            status, body = 500, ""
+            match = pattern.search(request.url)
+            if match.group(1) == "2":
+                status = 200
+                body = """
+<attributes>
+  <attribute name="OriginConfig" namespace="OSRT">
+    <value>origins:
+- &lt;devel&gt;: {}
+- SUSE:SLE-15:Update:
+    maintainer_review_initial: false
+- SUSE:SLE-15-SP1:Update:
+    maintainer_review_initial: false
+- SUSE:SLE-15-SP2:Update:
+    maintainer_review_initial: false
+- openSUSE:Leap:15.1:Update:
+    pending_submission_allow: true
+- openSUSE:Factory:
+    pending_submission_allow: true
+- '*~': {}
+fallback-group: 'origin-reviewers-maintenance'
+    </value>
+  </attribute>
+  <attribute name="Maintained" namespace="OBS"/>
+</attributes>"""
+            elif match.group(1) == "1":
+                status = 200
+                body = """
+<attributes>
+  <attribute name="OriginConfig" namespace="OSRT">
+    <value>origins:
+- &lt;devel&gt;: {}
+- SUSE:SLE-15*:
+    maintainer_review_initial: false
+- openSUSE:Factory:
+    pending_submission_allow: true
+- '*~': {}
+fallback-group: 'origin-reviewers-maintenance'
+    </value>
+  </attribute>
+  <attribute name="Maintained" namespace="OBS"/>
+</attributes>"""
+
+            return status, headers, body
+
+        def callback_proj(headers, params, request):
+            status, body = 500, ""
+            match_string = "".join(params.get("match", []))
+
+            if 'OSRT:OriginConfig' in match_string:
+                status = 200
+                body = """
+                <collection matches="2">
+                    <project name="openSUSE:Leap:15.1:Update"/>
+                    <project name="openSUSE:Leap:15.2:Update"/>
+                </collection>
+                """
+            elif "starts-with" in match_string:
+                status = 200
+                body = """
+                <collection matches="10">
+                  <project name='SUSE:SLE-15-SP1:GA'/>
+                  <project name='SUSE:SLE-15-SP1:Update'/>
+                  <project name='SUSE:SLE-15-SP2:GA'/>
+                  <project name='SUSE:SLE-15-SP2:Update'/>
+                  <project name='SUSE:SLE-15-SP2:Update:Products:MicroOS'/>
+                  <project name='SUSE:SLE-15-SP2:Update:Products:MicroOS:Update'/>
+                  <project name='SUSE:SLE-15-SP3:GA'/>
+                  <project name='SUSE:SLE-15-SP3:Update'/>
+                  <project name='SUSE:SLE-15:GA'/>
+                  <project name='SUSE:SLE-15:Update'/>
+                </collection>
+                """
+
+            return status, headers, body
+
+        self.mock_request(
+            method=responses.GET,
+            url=re.compile(self.osc.url + "/search/project/id"),
+            callback=CallbackFactory(callback_proj)
+        )
+        self.mock_request(
+            method=responses.GET,
+            url=re.compile(self.osc.url + r"/source/openSUSE:Leap:15\.[12]:Update/_attribute"),
+            callback=CallbackFactory(callback_attr)
+        )
+
+        self.assertEqual(
+            dict(self.osc.origins.expanded_origins),
+            {
+                "openSUSE:Leap:15.1:Update": [
+                    "<devel>", "SUSE:SLE-15-SP1:Update", "SUSE:SLE-15-SP1:GA", "SUSE:SLE-15:Update",
+                    "SUSE:SLE-15:GA", "openSUSE:Factory"
+                ],
+                "openSUSE:Leap:15.2:Update": [
+                    "<devel>", "SUSE:SLE-15-SP2:Update", "SUSE:SLE-15-SP1:Update",
+                    "SUSE:SLE-15:Update", "openSUSE:Leap:15.1:Update", "openSUSE:Factory"
+                ]
+            }
+        )

--- a/osctiny/tests/test_packages.py
+++ b/osctiny/tests/test_packages.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from io import StringIO, BytesIO, IOBase
 import re
 from unittest import skip
 
-from six import text_type
 import responses
 
 from .base import OscTest, CallbackFactory
@@ -159,7 +157,7 @@ class TestPackage(OscTest):
             response = self.osc.packages.get_meta(
                 "SUSE:SLE-12-SP1:Update", "python.8549", blame=True
             )
-            self.assertTrue(isinstance(response, text_type))
+            self.assertTrue(isinstance(response, str))
 
     @skip("No test data available")
     @responses.activate
@@ -248,7 +246,7 @@ class TestPackage(OscTest):
         response = self.osc.packages.cmd(
             "SUSE:SLE-12-SP1:Update", "python.8549", "diff"
         )
-        self.assertTrue(isinstance(response, text_type))
+        self.assertTrue(isinstance(response, str))
         self.assertIn(
             "++#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE", response
         )

--- a/osctiny/tests/test_projects.py
+++ b/osctiny/tests/test_projects.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
 import re
-from six.moves.urllib_parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 
 from lxml.objectify import fromstring
 from requests.exceptions import HTTPError

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import re
-
-from six.moves.urllib_parse import urlparse, parse_qs
-from six import text_type
+from urllib.parse import urlparse, parse_qs
 
 from lxml.objectify import ObjectifiedElement
 import responses
@@ -378,7 +375,7 @@ class TestRequest(OscTest):
     def test_cmd(self):
         with self.subTest("plain diff"):
             response = self.osc.requests.cmd(30902, "diff")
-            self.assertTrue(isinstance(response, text_type))
+            self.assertTrue(isinstance(response, str))
             self.assertIn("changes files:", response)
             self.assertIn("+++ perl-XML-DOM-XPath.changes", response)
         with self.subTest("xml diff"):

--- a/osctiny/tests/test_search.py
+++ b/osctiny/tests/test_search.py
@@ -1,8 +1,5 @@
-from __future__ import unicode_literals
-
 import re
-
-from six.moves.urllib_parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 import responses
 
 from .base import OscTest, CallbackFactory

--- a/osctiny/tests/test_utils.py
+++ b/osctiny/tests/test_utils.py
@@ -1,24 +1,13 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import sys
-
-if sys.version_info.major < 3:
-    from unittest2 import TestCase
-    import mock
-else:
-    from unittest import TestCase, mock
-
+from unittest import TestCase, mock
 from datetime import datetime
 from io import StringIO
 from os import remove
 from tempfile import mkstemp
 from types import GeneratorType
-from unittest import skipIf
 
 from dateutil.parser import parse
 from pytz import _UTC, timezone
-from six import text_type
 
 from ..utils.changelog import ChangeLog, Entry
 
@@ -136,7 +125,6 @@ class TestChangeLog(TestCase):
                 timestamp = parse(match.group("timestamp"))
                 self.assertIsInstance(timestamp, datetime)
 
-    @skipIf(sys.version_info.major < 3, "Python2 does not support this")
     def test_parse_non_generative(self):
         with mock.patch("osctiny.utils.changelog.open",
                         mock.mock_open(read_data=SAMPLE_CHANGES),
@@ -181,7 +169,6 @@ class TestChangeLog(TestCase):
         finally:
             remove(path)
 
-    @skipIf(sys.version_info.major < 3, "Python2 does not support this")
     def test_parse_generative(self):
         with mock.patch("osctiny.utils.changelog.open",
                         mock.mock_open(read_data=SAMPLE_CHANGES),
@@ -226,7 +213,7 @@ class TestChangeLog(TestCase):
             cl.write(path="/who/cares/test.changes")
 
             self.assertEqual(len(omock.mock_calls), 6)
-            content = "".join(text_type(omock.mock_calls[x][1][0])
+            content = "".join(str(omock.mock_calls[x][1][0])
                               for x in range(2, 5))
 
             self.assertEqual(
@@ -261,7 +248,6 @@ class TestChangeLog(TestCase):
                 "Føø Bar\n\n"
             )
 
-    @skipIf(sys.version_info.major < 3, "Python2 does not support this")
     def test_write_append(self):
         with mock.patch("osctiny.utils.changelog.open",
                         mock.mock_open(read_data=SAMPLE_CHANGES_2),
@@ -280,7 +266,7 @@ class TestChangeLog(TestCase):
             write_calls = [x for x in omock.mock_calls if x[0] == "().write"]
             self.assertEqual(len(write_calls), 5)
             self.assertEqual(
-                text_type(write_calls[0][1][0]),
+                str(write_calls[0][1][0]),
                 "-------------------------------------------------------------------\n"
                 "Sat Oct 31 00:00:00 UTC 2020 - Andreas Hasenkopf <ahasenkopf@suse.com>\n\n"
                 "New entry at the top\n\n"
@@ -318,7 +304,7 @@ class TestChangeLog(TestCase):
 
         self.assertIsInstance(cl.entries, list)
         self.assertEqual(len(cl.entries), 2)
-        self.assertIsInstance(cl.entries[0].timestamp, text_type)
+        self.assertIsInstance(cl.entries[0].timestamp, str)
         self.assertIsInstance(cl.entries[1].timestamp, datetime)
 
         self.assertEqual(wmock.call_count, 1)

--- a/osctiny/utils/backports.py
+++ b/osctiny/utils/backports.py
@@ -1,0 +1,18 @@
+"""
+Backports of handy new features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 0.3.0
+"""
+try:
+    # pylint: disable=unused-import
+    from functools import lru_cache
+except ImportError:
+    # Whoever had the grandiose idea to backport this to Python2?
+    # pylint: disable=unused-argument
+    def lru_cache(*args, **kwargs):
+        """Dummy wrapper"""
+        def wrapper(fun):
+            return fun
+
+        return wrapper

--- a/osctiny/utils/changelog.py
+++ b/osctiny/utils/changelog.py
@@ -11,7 +11,6 @@ from the openSUSE:Tools ``build`` package. See:
 
 .. versionadded:: 0.1.11
 """
-from __future__ import unicode_literals
 from datetime import datetime
 from io import TextIOBase
 import re
@@ -19,7 +18,6 @@ import warnings
 
 from dateutil.parser import parse
 from pytz import _UTC
-from six import text_type, binary_type
 
 
 def is_aware(timestamp):
@@ -156,7 +154,7 @@ class ChangeLog:
 
         if isinstance(handle, TextIOBase):
             handle.seek(0)
-        elif isinstance(handle, (text_type, binary_type)):
+        elif isinstance(handle, (str, bytes)):
             handle = open(handle, "r")
         else:
             raise TypeError("Unexpected type for 'path': {}".format(
@@ -261,11 +259,11 @@ class ChangeLog:
         def _wrapped(handle):
             for entry in sorted(self.entries, key=lambda x: x.timestamp,
                                 reverse=True):
-                handle.write(text_type(entry))
+                handle.write(str(entry))
 
         if isinstance(path, TextIOBase):
             _wrapped(path)
-        elif isinstance(path, (text_type, binary_type)):
+        elif isinstance(path, (str, bytes)):
             with open(path, "w") as handle:
                 _wrapped(handle)
         else:

--- a/osctiny/utils/mapping.py
+++ b/osctiny/utils/mapping.py
@@ -10,7 +10,7 @@ This module provides a collection of mapping types with special behavior.
 from collections.abc import MutableMapping
 
 
-class Mapable(MutableMapping):
+class Mappable(MutableMapping):
     """
     Basic implementation of a dictionary
     """
@@ -59,9 +59,9 @@ class Mapable(MutableMapping):
         return self._data.values()
 
 
-class LazyOscMapable(Mapable):
+class LazyOscMappable(Mappable):
     """
-    Base class for lazy mapables
+    Base class for lazy mappables
 
     To define custom subclasses override the ``__missing__`` method and set the missing key.
 

--- a/osctiny/utils/mapping.py
+++ b/osctiny/utils/mapping.py
@@ -1,0 +1,73 @@
+"""
+Mapping types
+^^^^^^^^^^^^^
+
+This module provides a collection of mapping types with special behavior.
+
+.. versionadded:: 0.3.0
+"""
+# pylint: disable=too-many-ancestors
+from collections.abc import MutableMapping
+
+
+class Mapable(MutableMapping):
+    """
+    Basic implementation of a dictionary
+    """
+    def __init__(self, **kwargs):
+        self._data = kwargs.copy()
+
+    def __getitem__(self, item):
+        if item not in self._data:
+            self.__missing__(item)
+        return self._data[item]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __iter__(self):
+        return self._data.__iter__()
+
+    def __len__(self):
+        return len(self._data)
+
+    def __delitem__(self, key):
+        del self._data[key]
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def __missing__(self, key):
+        raise KeyError(key)
+
+    def __str__(self):
+        return str(self._data)
+
+    def __repr__(self):
+        return repr(self._data)
+
+    def get(self, key, default=None):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def keys(self):
+        return self._data.keys()
+
+    def values(self):
+        return self._data.values()
+
+
+class LazyOscMapable(Mapable):
+    """
+    Base class for lazy mapables
+
+    To define custom subclasses override the ``__missing__`` method and set the missing key.
+
+    :param osc_obj: An Osc instance to run queries
+    :type osc_obj: :py:class:`osctiny.osc.Osc`
+    """
+    def __init__(self, osc_obj, **kwargs):
+        super().__init__(**kwargs)
+        self.osc = osc_obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+backports.cached-property
 lxml
 requests
 responses
 python-dateutil
 pytz
-six
+pyyaml

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -1,8 +1,0 @@
-lxml
-mock
-requests
-responses
-python-dateutil
-pytz
-unittest2
-six

--- a/requirements34.txt
+++ b/requirements34.txt
@@ -1,6 +1,0 @@
-lxml<4.4
-requests
-responses
-python-dateutil
-pytz
-six

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-import sys
 from setuptools import setup, find_packages
 
 
@@ -9,8 +7,7 @@ def get_requires():
     def _filter(requires):
         return [req.strip() for req in requires if req.strip()]
 
-    filename = "requirements.txt" if sys.version_info.major >= 3 \
-                                  else "requirements27.txt"
+    filename = "requirements.txt"
 
     with open(filename, "r") as fh:
         return _filter(fh.readlines())
@@ -22,7 +19,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.2.5',
+    version='0.3.0',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -39,11 +36,9 @@ setup(
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ]
 )


### PR DESCRIPTION
* Added the Origin extension
* Added the "mapping" utility
* Updated documentation
* Added tests
* Dropped support for Python 3.5 and older
* Added coverage report
* Bumped to version 0.3.0