### PR TITLE
Allow usage of origins extension without libyaml

### DIFF
--- a/doc/source/releasenotes.rst
+++ b/doc/source/releasenotes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+0.3.1
+-----
+
+* :py:mod:`osctiny.extensions.origin` does not require libyaml
+
 0.3.0
 -----
 

--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -20,13 +20,13 @@ logic than in the original OSC plugin is used:
 
 .. versionadded:: 0.3.0
 """
-# pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors,ungrouped-imports
 from collections import defaultdict
 import re
 from warnings import warn
 
 from lxml.objectify import ObjectifiedElement
-from yaml import load, CSafeLoader as SafeLoader
+from yaml import load
 
 from ..utils.backports import lru_cache
 from ..utils.base import ExtensionBase
@@ -37,6 +37,12 @@ try:
 except ImportError:
     # Support for Python3 prior 3.8
     from backports.cached_property import cached_property
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    # If libyaml installed, we should fall back to the SafeLoader
+    from yaml import SafeLoader
 
 
 class DevelProjects(LazyOscMappable):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.3.0',
+    version='0.3.1',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
If libyaml is not installed, clients can fallback
to `SafeLoader` instead of `CSafeLoader`.