### PR TITLE
False boolean parameters treat as True by OBS API

### DIFF
--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -262,9 +262,8 @@ class Osc:
         if not isinstance(params, dict):
             return {}
 
-        for key in params:
-            if isinstance(params[key], bool):
-                params[key] = '1' if params[key] else '0'
+        params = { **{key: '1' for key, v in params.items() if v is True},
+            **{key: v for key, v in params.items() if not isinstance(v, bool)}}
 
         return {key.encode(): str(value).encode()
                 for key, value in params.items()


### PR DESCRIPTION
### Issue  
OBS' APIs treat boolean parameters as flags. If a flag is present within the querystring, then it is **True** regardless of the assigned value: `?deleted`, `?deleted=1`, `?deleted=0` are all **True**.

### Root Cause Analysis
[`handle_params()`](https://github.com/crazyscientist/osc-tiny/blob/f3abb2c59ca210c8102d04380c215a9f113e8c1a/osctiny/osc.py#L236) sets all the **False** parameters to `0` instead of stripping them out.

https://github.com/crazyscientist/osc-tiny/blob/f3abb2c59ca210c8102d04380c215a9f113e8c1a/osctiny/osc.py#L265-L267

### Impact
This issue should impact all the API endpoints that set at least one boolean parameter as **False** by default.
For instance: the `deleted` parameter in [`/source`](https://build.suse.de/apidocs/index#25) is set **False** by default, this bug makes any issued request to always return only deleted projects instead of existing ones.

### Evidences

```bash
$ curl -su $OBS_AUTH2 -G "https://api.suse.de/source?deleted=0"
<status code="no_permission_for_deleted">
  <summary>only admins can see deleted projects</summary>
</status>
$ curl -su $OBS_AUTH2 -G "https://api.suse.de/source?deleted=1"
<status code="no_permission_for_deleted">
  <summary>only admins can see deleted projects</summary>
</status>
$ curl -su $OBS_AUTH2 -G "https://api.suse.de/source?deleted"
<status code="no_permission_for_deleted">
  <summary>only admins can see deleted projects</summary>
</status>
$ curl -sIu $OBS_AUTH2 -G "https://api.suse.de/source"
HTTP/2 200
date: Fri, 19 Feb 2021 09:50:41 GMT
```

### Proposed solution
This commit intends to remove from the querystring all the False boolean parameters.


###### Users with write access to crazyscientist/osc-tiny have write access to this PR too.