### PR TITLE
Checkout packages by following the _link file

### DIFF
--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -186,7 +186,7 @@ class Package(ExtensionBase):
 
     # pylint: disable=too-many-arguments
     def download_file(self, project, package, filename, destdir, meta=False,
-                      overwrite=False, rev=None, expand=0):
+                      overwrite=False, rev=None, expand=False):
         """
         Download a file to directory
 
@@ -343,7 +343,7 @@ class Package(ExtensionBase):
 
         return response.text
 
-    def checkout(self, project, package, destdir, rev=None, meta=False, expand=0):
+    def checkout(self, project, package, destdir, rev=None, meta=False, expand=False):
         """
         Checkout all files and directories of package
 

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -186,7 +186,7 @@ class Package(ExtensionBase):
 
     # pylint: disable=too-many-arguments
     def download_file(self, project, package, filename, destdir, meta=False,
-                      overwrite=False, rev=None):
+                      overwrite=False, rev=None, expand=0):
         """
         Download a file to directory
 
@@ -215,7 +215,7 @@ class Package(ExtensionBase):
         if not os.path.exists(destdir):
             os.makedirs(destdir)
 
-        response = self.get_file(project, package, filename, meta=meta, rev=rev)
+        response = self.get_file(project, package, filename, meta=meta, rev=rev, expand=expand)
 
         with open(abspath_filename, "wb") as handle:
             for chunk in response.iter_content(1024):
@@ -343,7 +343,7 @@ class Package(ExtensionBase):
 
         return response.text
 
-    def checkout(self, project, package, destdir, rev=None, meta=False):
+    def checkout(self, project, package, destdir, rev=None, meta=False, expand=0):
         """
         Checkout all files and directories of package
 
@@ -368,7 +368,7 @@ class Package(ExtensionBase):
         oscdir = DataDir(osc=self.osc, path=destdir, project=project,
                          package=package)
 
-        dirlist = self.get_files(project, package, rev=rev, meta=meta)
+        dirlist = self.get_files(project, package, rev=rev, meta=meta, expand=expand)
         for entry in dirlist.findall("entry"):
             self.download_file(
                 project=project,
@@ -377,7 +377,8 @@ class Package(ExtensionBase):
                 destdir=destdir,
                 meta=meta,
                 overwrite=True,
-                rev=rev
+                rev=rev,
+                expand=expand
             )
             os.link(
                 os.path.join(destdir, entry.get("name")),

--- a/pylint.rc
+++ b/pylint.rc
@@ -145,7 +145,8 @@ disable=print-statement,
         comprehension-escape,
         wildcard-import,
         unused-wildcard-import,
-        no-name-in-module
+        no-name-in-module,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
By adding the `expand` parameter to the checkout method a package can now be checked out by following the `_link` file, hence the latest version will be downloaded.
The parameter has been intentionally made optional and disabled by default, this way the involved API endpoints won't break.