### PR TITLE
Explicitly quote URLs (fixes #42)

### DIFF
--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -8,6 +8,7 @@ import gc
 import re
 from ssl import get_default_verify_paths
 import time
+from urllib.parse import quote
 import warnings
 
 # pylint: disable=no-name-in-module
@@ -218,7 +219,7 @@ class Osc:
 
         req = Request(
             method,
-            url,
+            url.replace("#", quote("#")).replace("?", quote("?")),
             auth=self.auth,
             data=self.handle_params(data),
             params=self.handle_params(params)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.4.1',
+    version='0.4.2',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `requests` module takes care of quoting URLs, but it does so after
parsing the URL. So, hashtags and question marks in the URL do not get
quoted.

OSC Tiny needs to quote these explicitly.