### PR TITLE
Fixed `HttpSignatureAuth`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2022, Andreas Hasenkopf'
 author = 'Andreas Hasenkopf'
 
 # The short X.Y version
-version = '0.6.1'
+version = '0.6.2'
 # The full version, including alpha/beta/rc tags
-release = '0.6.1'
+release = '0.6.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/osctiny/utils/auth.py
+++ b/osctiny/utils/auth.py
@@ -105,7 +105,7 @@ class HttpSignatureAuth(HTTPDigestAuth):
             r.request.body.seek(self._thread_local.pos)
         s_auth = r.headers.get('www-authenticate', '')
 
-        if s_auth.lower().startswith("signature") and self._thread_local.num_401_calls < 2:
+        if "signature" in s_auth.lower() and self._thread_local.num_401_calls < 2:
             self._thread_local.num_401_calls += 1
 
             _, challenge = s_auth.split(" ", maxsplit=1)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.6.1',
+    version='0.6.2',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When the server is supporting multiple auth. methods the
assumption that the header string becomes incorrect.