### PR TITLE
Dependency for backward compatibility

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -3,11 +3,11 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  test:
+  test_pre38:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.6, 3.7 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,34 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt coverage responses
+          pip install -r requirements.txt -r requirements_pre38.txt responses
+      - name: Test
+        run: python -m unittest discover
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.8, 3.9, '3.10' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt responses
       - name: Test
         run: python -m unittest discover
   lint:

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -35,10 +35,7 @@ try:
     from functools import cached_property
 except ImportError:
     # Support for Python3 prior 3.8
-    try:
-        from backports.cached_property import cached_property
-    except ImportError:
-        from cached_property import cached_property
+    from cached_property import cached_property
 
 try:
     from yaml import CSafeLoader as SafeLoader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-backports.cached-property
 lxml
 requests
 python-dateutil

--- a/requirements_pre38.txt
+++ b/requirements_pre38.txt
@@ -1,0 +1,1 @@
+cached-property

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from sys import version_info
 from setuptools import setup, find_packages
 
 
 def get_requires():
+    requirements = []
+
     def _filter(requires):
         return [req.strip() for req in requires if req.strip()]
 
-    filename = "requirements.txt"
+    with open("requirements.txt", "r") as fh:
+        requirements += _filter(fh.readlines())
 
-    with open(filename, "r") as fh:
-        return _filter(fh.readlines())
+    if version_info.minor < 8:
+        with open("requirements_pre38.txt", "r") as fh:
+            requirements += _filter(fh.readlines())
+
+    return requirements
 
 
 with open("README.md") as fh:


### PR DESCRIPTION
* Use `cached_property` instead of `backports.cached_property`
  (which is not in the openSUSE repos)
* Only install `cached_property` as requirement for Py3.7 and earlier
* Adjust GitHub actions