### PR TITLE
Omit the deleted parameter if its value is 0 when listing packages

### DIFF
--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -34,7 +34,7 @@ class Package(ExtensionBase):
         :return: Objectified XML element
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        params = {"deleted": deleted}
+        params = {"deleted": deleted} if deleted else {}
         response = self.osc.request(
             url=urljoin(self.osc.url, "{}/{}".format(self.base_path, project)),
             method="GET",


### PR DESCRIPTION
This is to workaround an inconsistent behavion on projects that have multibuild-
enabled packages.

Closes #72