### PR TITLE
buildresults: Return req.content instead of str

### DIFF
--- a/osctiny/extensions/buildresults.py
+++ b/osctiny/extensions/buildresults.py
@@ -125,7 +125,7 @@ class Build(ExtensionBase):
         :param package: Package name
         :param filename: File name
         :return: Raw response
-        :rtype: str
+        :rtype: bytes
 
         .. versionadded:: 0.2.4
         """
@@ -136,7 +136,7 @@ class Build(ExtensionBase):
             )),
         )
 
-        return response.text
+        return response.content
 
     def cmd(self, project, cmd, **params):
         """


### PR DESCRIPTION
Make get_binary return the binary encoded response, which matches the
expectation of a user that tries to download a binary file.

The function documentation was updated to reflect the new data type
returned.

Closes: #74

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>