### PR TITLE
Handle boolean query params (fixes #72)

### DIFF
--- a/osctiny/extensions/issues.py
+++ b/osctiny/extensions/issues.py
@@ -49,14 +49,14 @@ class Issue(ExtensionBase):
         )
         return self.osc.get_objectified_xml(response)
 
-    def get(self, tracker, name, force_update=None):
+    def get(self, tracker, name, force_update=False):
         """
         Get details for an issue
 
         :param str tracker: issue tracker name
         :param str name: issue name
-        :param force_update: If ``True``, BuildService will update the issue
-                             details internally prior to returning the response
+        :param bool force_update: If ``True``, BuildService will update the issue
+                                  details internally prior to returning the response
         :return: Objectified XML element
         :rtype: lxml.objectify.ObjectifiedElement
         """

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -497,7 +497,8 @@ class Origin(ExtensionBase):
             return None
 
         if resolve_inheritance:
-            response = self.osc.packages.get_files(package=package, project=project, withlinked=1)
+            response = self.osc.packages.get_files(package=package, project=project,
+                                                   withlinked=True)
             links = response.xpath("linkinfo/linked")
             if len(links) > 0:
                 project = links[-1].get("project")
@@ -535,7 +536,7 @@ class Origin(ExtensionBase):
             warn("Project {} has no origin definition".format(project))
             return
 
-        packages = self.osc.projects.get_files(project, expand='1')
+        packages = self.osc.projects.get_files(project, expand=True)
 
         for package in getattr(packages, "entry", []):
             name = package.get("name")

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -22,19 +22,23 @@ class Package(ExtensionBase):
     base_path = "/source"
     new_package_meta_templ = "<package><title/><description/></package>"
 
-    def get_list(self, project, deleted=False):
+    def get_list(self, project: str, deleted: bool = False, expand: bool = True):
         """
         Get packages from project
 
         .. versionadded:: 0.1.7
             Parameter ``deleted``
 
+        .. versionadded:: 0.7.0
+            Parameter ``expand``
+
         :param project: name of project
         :param deleted: Show deleted packages instead
+        :param expand: Include inherited packages and their project of origin
         :return: Objectified XML element
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        params = {"deleted": deleted}
+        params = {"deleted": deleted, "expand": expand}
         response = self.osc.request(
             url=urljoin(self.osc.url, "{}/{}".format(self.base_path, project)),
             method="GET",
@@ -148,7 +152,7 @@ class Package(ExtensionBase):
 
     # pylint: disable=too-many-arguments
     def get_file(self, project, package, filename, meta=False, rev=None,
-                 expand=0):
+                 expand=False):
         """
         Get a source file
 

--- a/osctiny/extensions/projects.py
+++ b/osctiny/extensions/projects.py
@@ -133,8 +133,7 @@ class Project(ExtensionBase):
         :return: Objectified XML element
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if meta:
-            kwargs["meta"] = '1'
+        kwargs["meta"] = meta
         if rev:
             kwargs["rev"] = text_type(rev)
         response = self.osc.request(
@@ -297,7 +296,8 @@ class Project(ExtensionBase):
         """
         if rev:
             kwargs["rev"] = rev
-        kwargs["meta"] = "1" if meta else "0"
+
+        kwargs["meta"] = meta
 
         response = self.osc.request(
             url=urljoin(self.osc.url, "{}/{}/_project/_history".format(

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -14,7 +14,7 @@ import re
 from ssl import get_default_verify_paths
 import time
 import threading
-from urllib.parse import quote
+from urllib.parse import quote, parse_qs
 import warnings
 
 # pylint: disable=no-name-in-module
@@ -35,7 +35,7 @@ from .extensions.bs_requests import Request as BsRequest
 from .extensions.search import Search
 from .extensions.users import Group, Person
 from .utils.auth import HttpSignatureAuth
-from .utils.conf import get_credentials
+from .utils.conf import BOOLEAN_PARAMS, get_credentials
 from .utils.errors import OscError
 
 try:
@@ -321,7 +321,7 @@ class Osc:
                          "\n".join(f"{k}: {v}" for k, v in req.data.items())
                          if isinstance(req.data, dict) else req.data)
             logger.debug("Sent parameters:\n%s\n---",
-                         "\n".join(f"{k}: {v}" for k, v in req.params.items()))
+                         "\n".join(f"{k}: {v}" for k, v in (req.params if isinstance(req.params, dict) else parse_qs(req.params, keep_blank_values=True)).items()))
             try:
                 response = session.send(prepped_req, **settings)
             except _ConnectionError as error:
@@ -349,7 +349,14 @@ class Osc:
         Translate request parameters to API conform format
 
         .. note:: The build service does not handle URL-encoded Unicode well.
-                  Therefore parameters are encoded as ``bytes``.
+                  Therefore, parameters are encoded as ``bytes``.
+
+        .. warning:: The build service does not declare its parameters properly and developers do
+                     `not intend to fix`_ this server-side. If you want to use _boolean_ parameters,
+                     make sure to use ``True`` and ``False``. If you use ``0`` or ``1`` instead, you
+                     might receive unexpected results.
+
+                     .. _not intend to fix: https://github.com/openSUSE/open-build-service/issues/9715
 
         :param params: Request parameter
         :type params: dict or str or io.BufferedReader
@@ -373,13 +380,26 @@ class Osc:
         if not isinstance(params, dict):
             return {}
 
-        for key in params:
-            if isinstance(params[key], bool):
-                params[key] = '1' if params[key] else '0'
+        # The OBS API has a weird expectation regarding boolean parameters and the maintainers have
+        # made it clear, that they are not going to clean up the API :(
+        # See: https://github.com/openSUSE/open-build-service/issues/9715
+        unexpected_bools = {key for key, value in params.items()
+                            if isinstance(value, bool) and key not in BOOLEAN_PARAMS}
+        if unexpected_bools:
+            warnings.warn(f"Received boolean query params, which are not expected to be: "
+                          f"{', '.join(unexpected_bools)}")
 
-        return {key.encode(): str(value).encode()
+        return "&".join(
+            quote(str(key))
+            if key in BOOLEAN_PARAMS or value is True
+            else f"{quote(str(key))}={quote(str(value))}"
+            for key, value in (
+                (key, value)
                 for key, value in params.items()
-                if value is not None}
+                if not ((key in BOOLEAN_PARAMS or isinstance(value, bool) or value is None)
+                        and value in [False, "0", 0, None])
+            )
+        ).encode()
 
     def get_objectified_xml(self, response):
         """

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -321,7 +321,11 @@ class Osc:
                          "\n".join(f"{k}: {v}" for k, v in req.data.items())
                          if isinstance(req.data, dict) else req.data)
             logger.debug("Sent parameters:\n%s\n---",
-                         "\n".join(f"{k}: {v}" for k, v in (req.params if isinstance(req.params, dict) else parse_qs(req.params, keep_blank_values=True)).items()))
+                         "\n".join(f"{k}: {v}" for k, v in (
+                             req.params
+                             if isinstance(req.params, dict)
+                             else parse_qs(req.params, keep_blank_values=True)
+                         ).items()))
             try:
                 response = session.send(prepped_req, **settings)
             except _ConnectionError as error:
@@ -356,7 +360,8 @@ class Osc:
                      make sure to use ``True`` and ``False``. If you use ``0`` or ``1`` instead, you
                      might receive unexpected results.
 
-                     .. _not intend to fix: https://github.com/openSUSE/open-build-service/issues/9715
+                     .. _not intend to fix: https://github.com/openSUSE/open-build-service/issues
+                                            /9715
 
         :param params: Request parameter
         :type params: dict or str or io.BufferedReader

--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
-from urllib.parse import unquote_plus
+from urllib.parse import unquote_plus, parse_qs
 
 import responses
 
@@ -21,23 +21,43 @@ class BasicTest(OscTest):
             ("føø bær", b"f\xc3\xb8\xc3\xb8 b\xc3\xa6r"),
             (
                 {"view": "xml", "withissues": 1},
-                {b"view": b"xml", b"withissues": b"1"}
+                b"view=xml&withissues=1"
             ),
             (
                 {"view": "xml", "withissues": True},
-                {b"view": b"xml", b"withissues": b"1"}
+                b"view=xml&withissues"
             ),
             (
                 {"view": "xml", "withissues": 0},
-                {b"view": b"xml", b"withissues": b"0"}
+                b"view=xml&withissues=0"
             ),
             (
                 {"view": "xml", "withissues": False},
-                {b"view": b"xml", b"withissues": b"0"}
+                b"view=xml"
             ),
             (
                 {"view": "xml", "withissues": None},
-                {b"view": b"xml"}
+                b"view=xml"
+            ),
+            (
+                {"view": "xml", "withissues": None},
+                b"view=xml"
+            ),
+            (
+                {"view": "xml", "deleted": 1},
+                b"view=xml&deleted"
+            ),
+            (
+                {"view": "xml", "deleted": 0},
+                b"view=xml"
+            ),
+            (
+                {"view": "xml", "deleted": False},
+                b"view=xml"
+            ),
+            (
+                {"view": "xml", "deleted": True},
+                b"view=xml&deleted"
             ),
         )
 
@@ -89,3 +109,30 @@ class BasicTest(OscTest):
         for name, filename in data:
             with self.subTest(name):
                 self.osc.request(f"{self.osc.url}file/{filename}")
+
+    @responses.activate
+    def test_request_boolean_params(self):
+        pattern = re.compile(self.osc.url + r'/\?(?P<query>.*)')
+
+        def callback(headers, params, request):
+            match = pattern.match(request.url)
+
+            parsed = parse_qs(match.group("query"), keep_blank_values=True)
+            self.assertEqual(parsed, expected)
+            return 200, headers, ""
+
+        self.mock_request(
+            method=responses.GET,
+            url=pattern,
+            callback=CallbackFactory(callback)
+        )
+
+        for path, expected in (
+                (b"foo", {"foo": [""]}),
+                (b"foo=bar", {"foo": ["bar"]}),
+                (b"foo=foo&bar", {"foo": ["foo"], "bar": [""]}),
+                (b"foo=foo?bar", {"foo": ["foo?bar"]}),
+                (b"foo=foo=bar", {"foo": ["foo=bar"]})
+        ):
+            with self.subTest(path):
+                self.osc.request(self.osc.url, params=path)

--- a/osctiny/tests/test_projects.py
+++ b/osctiny/tests/test_projects.py
@@ -24,8 +24,8 @@ class TestProject(OscTest):
             </directory>
             """
             parsed = urlparse(request.url)
-            params.update(parse_qs(parsed.query))
-            if params.get("deleted", ["0"]) == ["1"]:
+            params.update(parse_qs(parsed.query, keep_blank_values=True))
+            if "deleted" in params:
                 status = 403
                 body = """<status code="no_permission_for_deleted">
                   <summary>only admins can see deleted projects</summary>
@@ -165,9 +165,9 @@ class TestProject(OscTest):
                 </directory>
             """
             parsed = urlparse(request.url)
-            params.update(parse_qs(parsed.query))
+            params.update(parse_qs(parsed.query, keep_blank_values=True))
 
-            if params.get("meta", ['0']) == ['1']:
+            if "meta" in params:
                 status = 200
                 body = """
                     <directory name="_project" rev="41" vrev="" 

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -12,7 +12,7 @@ def callback(headers, params, request):
     status = 500
     body = ""
     parsed = urlparse(request.url)
-    params.update(parse_qs(parsed.query))
+    params.update(parse_qs(parsed.query, keep_blank_values=True))
 
     if re.search("comments/request/30902", request.url):
         status = 200
@@ -76,8 +76,7 @@ def callback(headers, params, request):
           <description>Required package for FATE#315181 (virt-v2v)
           </description>
         """
-        if params.get("withhistory", ['0']) == ['1'] \
-                or params.get("withfullhistory", ['0']) == ['1']:
+        if "withhistory" in params or "withfullhistory" in params:
             body += """
                 <history who="foo" when="2014-01-22T17:51:08">
                   <description>Request created</description>
@@ -97,7 +96,7 @@ def callback(headers, params, request):
                   </comment>
                 </history>
             """
-        if params.get("withfullhistory", ['0']) == ['1']:
+        if "withfullhistory" in params:
             body += """
                   <history who="acceptor" when="2014-01-23T19:24:37">
                     <description>Review got accepted</description>

--- a/osctiny/utils/conf.py
+++ b/osctiny/utils/conf.py
@@ -22,6 +22,30 @@ except ImportError:
     _conf = None
 
 
+# Query parameters that are considered to be boolean by the build service
+BOOLEAN_PARAMS = (
+    "add_repositories",
+    "deleted",
+    "emptylink",
+    "expand",
+    "extend_package_names",
+    "extend_package_names",
+    "ignoredevel",
+    "keeplink",
+    "lastbuild",
+    "lastworking",
+    "locallink",
+    "meta",
+    "multibuild",
+    "noaccess",
+    "parse",
+    "repairlink",
+    "update_path_elements",
+    "withdownloadurl",
+    "withlinked",
+)
+
+
 def get_config_path() -> Path:
     """
     Return path of ``osc`` configuration file


### PR DESCRIPTION
The build service has a rather specific interpretation of boolean parameters:
They are flags (i.e. without value) instead of params with explicit values.

This change explicitly tries to not send values for boolean params in order to
avoid confusing API responses.
(see e.g. https://github.com/openSUSE/open-build-service/issues/9715)