### PR TITLE
Make distinction between "true" booleans and pretenders (#72)

### DIFF
--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -389,22 +389,26 @@ class Osc:
         # The OBS API has a weird expectation regarding boolean parameters and the maintainers have
         # made it clear, that they are not going to clean up the API :(
         # See: https://github.com/openSUSE/open-build-service/issues/9715
+        # Also, there are parameters giving the impression that they are boolean, but actually are
+        # not.
         unexpected_bools = {key for key, value in params.items()
                             if isinstance(value, bool) and key not in BOOLEAN_PARAMS}
         if unexpected_bools:
             warnings.warn(f"Received boolean query params, which are not expected to be: "
                           f"{', '.join(unexpected_bools)}")
+            for key in unexpected_bools:
+                params[key] = '1' if params[key] else '0'
 
         return "&".join(
             quote(str(key))
-            if key in BOOLEAN_PARAMS or value is True
+            if key in BOOLEAN_PARAMS
             else f"{quote(str(key))}={quote(str(value))}"
             for key, value in (
                 (key, value)
                 for key, value in params.items()
-                if not ((key in BOOLEAN_PARAMS or isinstance(value, bool) or value is None)
-                        and value in [False, "0", 0, None])
+                if not (key in BOOLEAN_PARAMS and value in [False, "0", 0, None, ""])
             )
+            if value is not None
         ).encode()
 
     def download(self, url, destdir, destfile=None, overwrite=False, **params):

--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -58,13 +58,14 @@ class BasicTest(OscTest):
             (1, {}),
             ("hello world", b"hello world"),
             ("føø bær", b"f\xc3\xb8\xc3\xb8 b\xc3\xa6r"),
+            # 'withissues' is not a boolean param in the API
             (
                 {"view": "xml", "withissues": 1},
                 b"view=xml&withissues=1"
             ),
             (
                 {"view": "xml", "withissues": True},
-                b"view=xml&withissues"
+                b"view=xml&withissues=1"
             ),
             (
                 {"view": "xml", "withissues": 0},
@@ -72,22 +73,27 @@ class BasicTest(OscTest):
             ),
             (
                 {"view": "xml", "withissues": False},
-                b"view=xml"
+                b"view=xml&withissues=0"
             ),
             (
                 {"view": "xml", "withissues": None},
                 b"view=xml"
             ),
-            (
-                {"view": "xml", "withissues": None},
-                b"view=xml"
-            ),
+            # 'deleted' is a boolean param in the API
             (
                 {"view": "xml", "deleted": 1},
                 b"view=xml&deleted"
             ),
             (
                 {"view": "xml", "deleted": 0},
+                b"view=xml"
+            ),
+            (
+                {"view": "xml", "deleted": "1"},
+                b"view=xml&deleted"
+            ),
+            (
+                {"view": "xml", "deleted": "0"},
                 b"view=xml"
             ),
             (

--- a/osctiny/tests/test_build.py
+++ b/osctiny/tests/test_build.py
@@ -15,7 +15,7 @@ class BuildTest(OscTest):
             status = 500
             body = ""
             parsed = urlparse(request.url)
-            params.update(parse_qs(parsed.query))
+            params.update(parse_qs(parsed.query, keep_blank_values=True))
 
             if not params:
                 status = 200

--- a/osctiny/tests/test_issues.py
+++ b/osctiny/tests/test_issues.py
@@ -105,7 +105,7 @@ class TestIssue(OscTest):
         def callback(headers, params, request):
             parsed = urlparse(request.url)
             query_params = parse_qs(parsed.query, keep_blank_values=True)
-            if "force_update" in query_params:
+            if query_params.get("force_update", ["0"]) == ["1"]:
                 status, body = 200, u"""
                 <issue>
                   <created_at>2020-01-04 14:12:00 UTC</created_at>
@@ -134,8 +134,7 @@ class TestIssue(OscTest):
 
         self.mock_request(
             method=responses.GET,
-            url=re.compile(self.osc.url +
-                           r'/issue_trackers/bnc/issues/1160086/?.*'),
+            url=re.compile(self.osc.url + r'/issue_trackers/bnc/issues/1160086/?.*'),
             callback=CallbackFactory(callback)
         )
 

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -76,7 +76,8 @@ def callback(headers, params, request):
           <description>Required package for FATE#315181 (virt-v2v)
           </description>
         """
-        if "withhistory" in params or "withfullhistory" in params:
+        if params.get("withhistory", ['0']) == ['1'] \
+                or params.get("withfullhistory", ['0']) == ['1']:
             body += """
                 <history who="foo" when="2014-01-22T17:51:08">
                   <description>Request created</description>
@@ -96,7 +97,7 @@ def callback(headers, params, request):
                   </comment>
                 </history>
             """
-        if "withfullhistory" in params:
+        if params.get("withfullhistory", ['0']) == ['1']:
             body += """
                   <history who="acceptor" when="2014-01-23T19:24:37">
                     <description>Review got accepted</description>

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.7.0',
+    version='0.7.1',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
While the IBS API has explicit boolean parameters, it also has
parameters, which pretend to be boolean, but are not.

In order to keep client working and shield them from this madness
this is a workaround to the existing workaround (#77).