### PR TITLE
Officially removed support for Python2 (closes #81)

### DIFF
--- a/osctiny/extensions/bs_requests.py
+++ b/osctiny/extensions/bs_requests.py
@@ -2,9 +2,7 @@
 Requests extension
 ------------------
 """
-from __future__ import unicode_literals
-from six.moves.urllib.parse import urljoin
-from six import text_type
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 
@@ -17,7 +15,7 @@ class Request(ExtensionBase):
 
     @staticmethod
     def _validate_id(request_id):
-        request_id = text_type(request_id)
+        request_id = str(request_id)
         if not request_id.isnumeric():
             raise ValueError(
                 "Request ID must be numeric! Got instead: {}".format(request_id)

--- a/osctiny/extensions/buildresults.py
+++ b/osctiny/extensions/buildresults.py
@@ -3,8 +3,7 @@ Build result extension
 ----------------------
 """
 # pylint: disable=too-few-public-methods
-from __future__ import unicode_literals
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/extensions/comments.py
+++ b/osctiny/extensions/comments.py
@@ -2,10 +2,8 @@
 Comments extension
 ------------------
 """
-from __future__ import unicode_literals
 import os
-from six.moves.urllib.parse import urljoin
-from six import text_type
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 
@@ -53,7 +51,7 @@ class Comment(ExtensionBase):
         response = self.osc.request(
             url=urljoin(self.osc.url,
                         os.path.join(*([self.base_path, obj_type]
-                                       + [text_type(x) for x in ids]))),
+                                       + [str(x) for x in ids]))),
             method="GET",
         )
         return self.osc.get_objectified_xml(response)
@@ -81,9 +79,9 @@ class Comment(ExtensionBase):
         """
         self._validate(obj_type, ids)
         url = urljoin(self.osc.url,
-                      os.path.join(*([self.base_path, obj_type] + [text_type(x) for x in ids])))
+                      os.path.join(*([self.base_path, obj_type] + [str(x) for x in ids])))
         params = {}
-        if parent_id and text_type(parent_id).isnumeric():
+        if parent_id and str(parent_id).isnumeric():
             params["parent_id"] = parent_id
 
         response = self.osc.request(
@@ -109,7 +107,7 @@ class Comment(ExtensionBase):
         :return: ``True``, if successful. Otherwise API response
         :rtype: bool or lxml.objectify.ObjectifiedElement
         """
-        url = urljoin(self.osc.url, '/comment/' + text_type(comment_id))
+        url = urljoin(self.osc.url, '/comment/' + str(comment_id))
 
         response = self.osc.request(
             url=url,

--- a/osctiny/extensions/distributions.py
+++ b/osctiny/extensions/distributions.py
@@ -2,10 +2,7 @@
 Distributions extension
 -----------------------
 """
-from __future__ import unicode_literals
-
-from six.moves.urllib.parse import urljoin
-from six import text_type
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 
@@ -49,7 +46,7 @@ class Distribution(ExtensionBase):
         response = self.osc.request(
             url=urljoin(
                 self.osc.url,
-                "/".join((self.base_path, text_type(distribution_id)))
+                "/".join((self.base_path, str(distribution_id)))
             ),
             method="GET"
         )

--- a/osctiny/extensions/issues.py
+++ b/osctiny/extensions/issues.py
@@ -2,11 +2,9 @@
 Issues extension
 ----------------
 """
-from __future__ import unicode_literals
 import os
 
-from six.moves.urllib.parse import urljoin
-from six import text_type
+from urllib.parse import urljoin
 
 from ..utils.backports import lru_cache
 from ..utils.base import ExtensionBase
@@ -22,7 +20,7 @@ class Issue(ExtensionBase):
 
     @staticmethod
     def _validate(value):
-        return text_type(value)
+        return str(value)
 
     @lru_cache(maxsize=1)
     def get_trackers(self):

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -2,10 +2,8 @@
 Packages extension
 ------------------
 """
-from __future__ import unicode_literals
 import os
-from six.moves.urllib.parse import urljoin
-from six import text_type
+from urllib.parse import urljoin
 
 from lxml.etree import tounicode, SubElement, Element
 from lxml.objectify import fromstring
@@ -105,7 +103,7 @@ class Package(ExtensionBase):
         :type meta: str or lxml.objectify.ObjectifiedElement
         :return:
         """
-        if isinstance(meta, text_type):
+        if isinstance(meta, (str, bytes)):
             meta = fromstring(meta)
 
         if meta is not None:

--- a/osctiny/extensions/projects.py
+++ b/osctiny/extensions/projects.py
@@ -2,12 +2,9 @@
 Projects extension
 ------------------
 """
-from __future__ import unicode_literals
 import re
+from urllib.parse import urljoin
 from warnings import warn
-
-from six.moves.urllib.parse import urljoin
-from six import text_type
 
 from lxml.etree import tounicode
 from lxml.objectify import fromstring, SubElement
@@ -113,7 +110,7 @@ class Project(ExtensionBase):
         if metafile is None:
             metafile = TEMPLATE_META
 
-        if isinstance(metafile, text_type):
+        if isinstance(metafile, (str, bytes)):
             metafile = fromstring(metafile)
 
         metafile.set("name", project)
@@ -171,7 +168,7 @@ class Project(ExtensionBase):
         """
         kwargs["meta"] = meta
         if rev:
-            kwargs["rev"] = text_type(rev)
+            kwargs["rev"] = str(rev)
         response = self.osc.request(
             url=urljoin(
                 self.osc.url,
@@ -244,7 +241,7 @@ class Project(ExtensionBase):
         for val in value:
             elem = SubElement(attr_xml.attribute, "value")
             # pylint: disable=protected-access
-            elem._setText(text_type(val))
+            elem._setText(str(val))
 
         response = self.osc.request(
             url=url,

--- a/osctiny/extensions/search.py
+++ b/osctiny/extensions/search.py
@@ -2,8 +2,7 @@
 Search extension
 ----------------
 """
-from __future__ import unicode_literals
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/extensions/users.py
+++ b/osctiny/extensions/users.py
@@ -2,8 +2,7 @@
 Persons and groups extension
 ----------------------------
 """
-from __future__ import unicode_literals
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 from ..utils.base import ExtensionBase
 

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -129,7 +129,7 @@ class Osc:
     default_connection_retries = 5
     default_retry_timeout = 5
 
-    def __init__(self, url: str = None, username: typing.Optional[str] = None,
+    def __init__(self, url: typing.Optional[str] = None, username: typing.Optional[str] = None,
                  password: typing.Optional[str] = None, verify: typing.Optional[str] = None,
                  cache: bool = False,
                  ssh_key_file: typing.Optional[typing.Union[Path, str]] = None):


### PR DESCRIPTION
* Removed imports from `__future__`
* Replaced imports from `six` with imports from builtin modules