### PR TITLE
Consider "boolean" parameters of specific API endpoints (fixes #97)

### DIFF
--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/osctiny/extensions/origin.py
+++ b/osctiny/extensions/origin.py
@@ -27,15 +27,9 @@ from warnings import warn
 
 from yaml import load
 
-from ..utils.backports import lru_cache
+from ..utils.backports import lru_cache, cached_property
 from ..utils.base import ExtensionBase
 from ..utils.mapping import LazyOscMappable
-
-try:
-    from functools import cached_property
-except ImportError:
-    # Support for Python3 prior 3.8
-    from cached_property import cached_property
 
 try:
     from yaml import CSafeLoader as SafeLoader

--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -49,8 +49,9 @@ class BasicTest(OscTest):
                 tmpfile2.unlink()
 
     def test_handle_params(self):
-        def _run(data, expected):
-            handled = self.osc.handle_params(data)
+        def _run(data, expected, url="https://api.example.com/source/PROJECT/PACKAGE",
+                 method="GET"):
+            handled = self.osc.handle_params(url=url, method=method, params=data)
             self.assertEqual(handled, expected)
 
         data = (
@@ -79,7 +80,7 @@ class BasicTest(OscTest):
                 {"view": "xml", "withissues": None},
                 b"view=xml"
             ),
-            # 'deleted' is a boolean param in the API
+            # 'deleted' is a boolean param in the project endpoint
             (
                 {"view": "xml", "deleted": 1},
                 b"view=xml&deleted"
@@ -104,11 +105,33 @@ class BasicTest(OscTest):
                 {"view": "xml", "deleted": True},
                 b"view=xml&deleted"
             ),
+            # 'expand' is no boolean param in the project endpoint
+            (
+                {"expand": True},
+                b"expand=1",
+                "https://api.example.com/source/PROJECT",
+            ),
+            (
+                {"expand": False},
+                b"expand=0",
+                "https://api.example.com/source/PROJECT",
+            ),
+            # 'expand' is a boolean param in the package endpoint
+            (
+                {"expand": False},
+                b"",
+                "https://api.example.com/source/PROJECT/PACKAGE",
+            ),
+            (
+                {"expand": True},
+                b"expand",
+                "https://api.example.com/source/PROJECT/PACKAGE",
+            ),
         )
 
-        for params, expected in data:
-            with self.subTest(params):
-                _run(params, expected)
+        for dataset in data:
+            with self.subTest(dataset[0]):
+                _run(*dataset)
 
     def test_attrib_regexp(self):
         def _run(attr, expected):

--- a/osctiny/tests/test_projects.py
+++ b/osctiny/tests/test_projects.py
@@ -25,7 +25,7 @@ class TestProject(OscTest):
             """
             parsed = urlparse(request.url)
             params.update(parse_qs(parsed.query, keep_blank_values=True))
-            if "deleted" in params:
+            if params["deleted"] == ["1"]:
                 status = 403
                 body = """<status code="no_permission_for_deleted">
                   <summary>only admins can see deleted projects</summary>

--- a/osctiny/utils/backports.py
+++ b/osctiny/utils/backports.py
@@ -16,3 +16,11 @@ except ImportError:
             return fun
 
         return wrapper
+
+
+try:
+    # pylint: disable=unused-import
+    from functools import cached_property
+except ImportError:
+    # Support for Python3 prior 3.8
+    from cached_property import cached_property

--- a/osctiny/utils/conf.py
+++ b/osctiny/utils/conf.py
@@ -23,27 +23,22 @@ except ImportError:
 
 
 # Query parameters that are considered to be boolean by the build service
-BOOLEAN_PARAMS = (
-    "add_repositories",
-    "deleted",
-    "emptylink",
-    "expand",
-    "extend_package_names",
-    "extend_package_names",
-    "ignoredevel",
-    "keeplink",
-    "lastbuild",
-    "lastworking",
-    "locallink",
-    "meta",
-    "multibuild",
-    "noaccess",
-    "parse",
-    "repairlink",
-    "update_path_elements",
-    "withdownloadurl",
-    "withlinked",
-)
+BOOLEAN_PARAMS = {
+    "^/source/[^/]+/[^/]+/?$": {
+        'GET': ('emptylink', 'expand', 'meta', 'lastworking', 'withlinked', 'deleted', 'parse'),
+        'POST': ('ignoredevel', 'add_repositories', 'noaccess', 'update_path_elements',
+                 'extend_package_names', 'extend_package_names', 'keeplink', 'repairlink')
+    },
+    "^/source/[^/]+/[^/]+/[^/]+$": {
+        'PUT': ('keeplink',)
+    },
+    "^/build/[^/]+/_result$": {
+        'GET': ('lastbuild', 'locallink', 'multibuild')
+    },
+    "search/published/(binary|repoinfo|pattern)/id$": {
+        'GET': ('withdownloadurl',)
+    }
+}
 
 
 def get_config_path() -> Path:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.7.2',
+    version='0.7.3',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Refactored list of boolean parameter flags into a dictionary
* Extended tests
* Moved fallback imports of `cached_property` to `backports`