### PR TITLE
Workaround for another inconsistency in the OBS API

### DIFF
--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/osctiny/extensions/projects.py
+++ b/osctiny/extensions/projects.py
@@ -174,13 +174,13 @@ class Project(ExtensionBase):
             The API URL used by this method is (depending on the value of ``directory``) identical
             to the one used by the above two methods.
         """
-        kwargs["meta"] = meta
         if rev:
             kwargs["rev"] = str(rev)
 
         if not directory:
             return self.osc.packages.get_list(project=project, **kwargs)
 
+        kwargs["meta"] = meta
         return self.osc.packages.get_files(project=project, package=directory, **kwargs)
 
     def get_attribute(self, project, attribute=None):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.7.4',
+    version='0.7.5',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* Explicitly do not set the `meta` parameter in `Project.get_files`, when deferring to `Package.get_list`
* Bump version to 0.7.5