### PR TITLE
Surprise, another parameter conflict in the OBS API

### DIFF
--- a/osctiny/__init__.py
+++ b/osctiny/__init__.py
@@ -6,4 +6,4 @@ from .extensions import bs_requests, buildresults, comments, packages, \
 
 __all__ = ['Osc', 'bs_requests', 'buildresults', 'comments', 'packages',
            'projects', 'search', 'users']
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -32,11 +32,15 @@ class Package(ExtensionBase):
 
         .. versionadded::0.7.4
         """
-        if params.get("view", None) == "info":
+        view = params.get("view", "")
+        if view == "info":
             # The 'info' view is strict about parameter validation
             return {key: value for key, value in params.items()
                     if key in ["parse", "arch", "repository", "view"]}
-
+        if "productlist" in view:
+            # The "deleted" parameter seems to have precedence over other acceptable parameters
+            # (e.g. "view")
+            return {key: value for key, value in params.items() if key not in ["deleted"]}
         return params
 
     def get_list(self, project: str, deleted: bool = False, expand: bool = True, **params):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md") as fh:
 
 setup(
     name='osc-tiny',
-    version='0.7.5',
+    version='0.7.6',
     description='Client API for openSUSE BuildService',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The `deleted` parameter interferes with other `view` parameter values, too.

This is another fallout of https://github.com/openSUSE/open-build-service/issues/9715