### PR TITLE
Treat deleted and expand parameters as boolean when listing project packages

### DIFF
--- a/osctiny/tests/test_basic.py
+++ b/osctiny/tests/test_basic.py
@@ -105,17 +105,29 @@ class BasicTest(OscTest):
                 {"view": "xml", "deleted": True},
                 b"view=xml&deleted"
             ),
-            # 'expand' is no boolean param in the project endpoint
+            # 'expand' is a boolean param in the project endpoint
             (
                 {"expand": True},
-                b"expand=1",
+                b"expand",
                 "https://api.example.com/source/PROJECT",
             ),
             (
                 {"expand": False},
-                b"expand=0",
+                b"",
                 "https://api.example.com/source/PROJECT",
             ),
+            # 'deleted' is a boolean param in the project endpoint
+            (
+                {"deleted": True},
+                b"deleted",
+                "https://api.example.com/source/PROJECT",
+            ),
+            (
+                {"deleted": False},
+                b"",
+                "https://api.example.com/source/PROJECT",
+            ),
+
             # 'expand' is a boolean param in the package endpoint
             (
                 {"expand": False},

--- a/osctiny/utils/conf.py
+++ b/osctiny/utils/conf.py
@@ -29,6 +29,9 @@ BOOLEAN_PARAMS = {
         'POST': ('ignoredevel', 'add_repositories', 'noaccess', 'update_path_elements',
                  'extend_package_names', 'extend_package_names', 'keeplink', 'repairlink')
     },
+    "^/source/[^/]+/?$": {
+        'GET': ('expand', 'deleted'),
+    },
     "^/source/[^/]+/[^/]+/[^/]+$": {
         'PUT': ('keeplink',)
     },


### PR DESCRIPTION
This means treating those parameters as boolean when calling GET /source/<project>/

Closes #106