### PR TITLE
Handle another parameter conflict in the API

### DIFF
--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -3,6 +3,7 @@ Packages extension
 ------------------
 """
 import os
+import typing
 from urllib.parse import urljoin
 
 from lxml.etree import tounicode, SubElement, Element
@@ -20,7 +21,7 @@ class Package(ExtensionBase):
     new_package_meta_templ = "<package><title/><description/></package>"
 
     @staticmethod
-    def cleanup_params(**params) -> dict:
+    def cleanup_params(**params) -> typing.Union[dict, str]:
         """
         Prepare query parameters
 
@@ -30,7 +31,10 @@ class Package(ExtensionBase):
         :param params: Query parameters
         :return: The original dictionary of query parameters or a subset of it
 
-        .. versionadded::0.7.4
+        .. versionadded:: 0.7.4
+
+        .. versionchanged:: 0.7.7
+            Handle more inconsistencies in the API endpoints
         """
         view = params.get("view", "")
         if view == "info":
@@ -40,7 +44,8 @@ class Package(ExtensionBase):
         if "productlist" in view:
             # The "deleted" parameter seems to have precedence over other acceptable parameters
             # (e.g. "view")
-            return {key: value for key, value in params.items() if key not in ["deleted"]}
+            # Also, in views boolean params are not recognized as such
+            return f"view={view}&expand=0"
         return params
 
     def get_list(self, project: str, deleted: bool = False, expand: bool = False, **params):

--- a/osctiny/osc.py
+++ b/osctiny/osc.py
@@ -373,7 +373,9 @@ class Osc:
 
         return ()
 
-    def handle_params(self, url, method, params):
+    def handle_params(self, url: str, method: str,
+                      params: typing.Union[bytes, str, StringIO, BytesIO, BufferedReader, dict]) \
+            -> bytes:
         """
         Translate request parameters to API conform format
 

--- a/osctiny/tests/test_packages.py
+++ b/osctiny/tests/test_packages.py
@@ -394,7 +394,6 @@ class TestPackage(OscTest):
                                         comment=the_comment)
             self.assertEqual(received_params[-1]["comment"], [the_comment])
 
-
     @responses.activate
     def test_aggregate(self):
         put_called = []
@@ -479,3 +478,28 @@ class TestPackage(OscTest):
                 "test:project2:exists", "test.pkg",
             )
             self.assertEqual(len(put_called), old_len + 1)
+
+    def test_cleanup_params(self):
+        with self.subTest("No view"):
+            params = {"deleted": True, "expand": True}
+            self.assertEqual(params, self.osc.packages.cleanup_params(**params))
+
+        with self.subTest("view=info"):
+            self.assertEqual({"view": "info"},
+                             self.osc.packages.cleanup_params(view="info", deleted=True))
+
+        with self.subTest("view=productlist"):
+            expected = "view=productlist&expand=0"
+            self.assertEqual(expected,
+                             self.osc.packages.cleanup_params(view="productlist", deleted=True))
+            self.assertEqual(expected,
+                             self.osc.packages.cleanup_params(view="productlist", expand=True))
+
+        with self.subTest("view=verboseproductlist"):
+            expected = "view=verboseproductlist&expand=0"
+            self.assertEqual(expected,
+                             self.osc.packages.cleanup_params(view="verboseproductlist",
+                                                              deleted=True))
+            self.assertEqual(expected,
+                             self.osc.packages.cleanup_params(view="verboseproductlist",
+                                                              expand=True))


### PR DESCRIPTION
This is a workaround for https://github.com/openSUSE/open-build-service/issues/13301