### PR TITLE
Replaced `Request.cmd` with `Request.update` (fixes #113)

### DIFF
--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -372,20 +372,15 @@ class TestRequest(OscTest):
             self.assertEqual(len(response.xpath("//request/history")), 5)
 
     @responses.activate
-    def test_cmd(self):
-        with self.subTest("plain diff"):
-            response = self.osc.requests.cmd(30902, "diff")
+    def test_update(self):
+        with self.subTest("cmd=diff, plain"):
+            response = self.osc.requests.update(30902, cmd="diff")
             self.assertTrue(isinstance(response, str))
             self.assertIn("changes files:", response)
             self.assertIn("+++ perl-XML-DOM-XPath.changes", response)
-        with self.subTest("xml diff"):
-            response = self.osc.requests.cmd(30902, "diff", view="xml")
+        with self.subTest("cmd=diff, xml"):
+            response = self.osc.requests.update(30902, cmd="diff", view="xml")
             self.assertTrue(isinstance(response, ObjectifiedElement))
-        with self.subTest("changereviewstate"):
-            self.assertRaises(
-                ValueError,
-                self.osc.requests.cmd, 30902, "changereviewstate"
-            )
 
     @responses.activate
     def test_comment(self):


### PR DESCRIPTION
* Added new generic method `Request.update`
* `Request.cmd`
  * Marked as deprecated
  * Removed checks for allowed commands and states
  * Internally call `Request.update`
* Changed testsuite to cover `Request.update` instead of `Request.cmd`