### PR TITLE
Support product list views honoring the `expand` parameter

### DIFF
--- a/osctiny/extensions/packages.py
+++ b/osctiny/extensions/packages.py
@@ -43,9 +43,9 @@ class Package(ExtensionBase):
                     if key in ["parse", "arch", "repository", "view"]}
         if "productlist" in view:
             # The "deleted" parameter seems to have precedence over other acceptable parameters
-            # (e.g. "view")
-            # Also, in views boolean params are not recognized as such
-            return f"view={view}&expand=0"
+            # (e.g. "view").
+            # Product list views now honor the `expand` parameter.
+            return f"view={view}&expand={'1' if params.get('expand') else '0'}"
         return params
 
     def get_list(self, project: str, deleted: bool = False, expand: bool = False, **params):

--- a/osctiny/tests/test_packages.py
+++ b/osctiny/tests/test_packages.py
@@ -513,10 +513,10 @@ class TestPackage(OscTest):
                              self.osc.packages.cleanup_params(view="productlist", expand=True))
 
         with self.subTest("view=verboseproductlist"):
-            self.assertEqual("view=productlist&expand=0",
+            self.assertEqual("view=verboseproductlist&expand=0",
                              self.osc.packages.cleanup_params(view="verboseproductlist",
                                                               deleted=True))
-            self.assertEqual("view=productlist&expand=1",
+            self.assertEqual("view=verboseproductlist&expand=1",
                              self.osc.packages.cleanup_params(view="verboseproductlist",
                                                               expand=True))
 

--- a/osctiny/tests/test_packages.py
+++ b/osctiny/tests/test_packages.py
@@ -507,18 +507,16 @@ class TestPackage(OscTest):
                              self.osc.packages.cleanup_params(view="info", deleted=True))
 
         with self.subTest("view=productlist"):
-            expected = "view=productlist&expand=0"
-            self.assertEqual(expected,
+            self.assertEqual("view=productlist&expand=0",
                              self.osc.packages.cleanup_params(view="productlist", deleted=True))
-            self.assertEqual(expected,
+            self.assertEqual("view=productlist&expand=1",
                              self.osc.packages.cleanup_params(view="productlist", expand=True))
 
         with self.subTest("view=verboseproductlist"):
-            expected = "view=verboseproductlist&expand=0"
-            self.assertEqual(expected,
+            self.assertEqual("view=productlist&expand=0",
                              self.osc.packages.cleanup_params(view="verboseproductlist",
                                                               deleted=True))
-            self.assertEqual(expected,
+            self.assertEqual("view=productlist&expand=1",
                              self.osc.packages.cleanup_params(view="verboseproductlist",
                                                               expand=True))
 


### PR DESCRIPTION
As of recently, the `productlist` and `verboseproductlist` views
honor the `expand` parameter.

See: https://github.com/openSUSE/open-build-service/issues/13301